### PR TITLE
fix: 防止 Jira 等弹框抢走翻译输入框焦点

### DIFF
--- a/content/content-input-dialog.js
+++ b/content/content-input-dialog.js
@@ -221,12 +221,29 @@
 
     // Escape to close (capture phase to intercept before other keydown handlers)
     document.addEventListener('keydown', handleInputDialogEscape, true);
+
+    // Prevent host-page focus traps (e.g. Jira/Atlaskit modals built on
+    // focus-lock) from stealing focus out of our dialog. Such traps listen for
+    // focus events bubbling to `document` and forcibly redirect focus back into
+    // their own modal whenever focus lands outside it — which would silently
+    // route the user's keystrokes into the host modal instead of our textarea.
+    // We intercept focus events targeting our dialog in the capture phase and
+    // stop them before the host page's bubble-phase listeners can react.
+    document.addEventListener('focusin', blockHostFocusTrap, true);
+    document.addEventListener('focusout', blockHostFocusTrap, true);
   }
 
   function handleInputDialogEscape(e) {
     if (e.key === 'Escape' && state.inputDialog) {
       e.stopImmediatePropagation();
       hideInputDialog();
+    }
+  }
+
+  function blockHostFocusTrap(e) {
+    const dialog = state.inputDialog;
+    if (dialog && (e.target === dialog || dialog.contains(e.target))) {
+      e.stopImmediatePropagation();
     }
   }
 
@@ -238,6 +255,8 @@
       state.inputDialog.remove();
       state.inputDialog = null;
       document.removeEventListener('keydown', handleInputDialogEscape, true);
+      document.removeEventListener('focusin', blockHostFocusTrap, true);
+      document.removeEventListener('focusout', blockHostFocusTrap, true);
     }
   }
 


### PR DESCRIPTION
## 问题

在已打开 Jira 弹框的页面上唤起「输入翻译」框时，输入的内容会被悄悄送进 Jira 弹框里的输入框，而不是我们的翻译框 —— 看起来像扩展"无法识别自己的弹框"。

## 根因

不是 z-index 层级问题（翻译框 z-index 已是最大值，视觉上盖在最上层）。

Jira 弹框基于 Atlassian `@atlaskit/modal-dialog`（底层 `react-focus-lock`），它在 `document` 上安装了**焦点锁**：监听冒泡到 `document` 的 `focusin`，一旦焦点落到自己弹框容器之外，就强制把焦点抢回 Jira 弹框内部。

我们的 `textarea.focus()` 触发的 `focusin` 冒泡到 `document` 后被 focus-lock 捕获 → 焦点被抢回 Jira → 用户键入内容进了 Jira 的字段。

## 修复

输入框打开期间，在 `document` 的**捕获阶段**拦截「目标在我们弹框内部」的 `focusin`/`focusout`，在 focus-lock 的冒泡监听器执行前调用 `stopImmediatePropagation()` 掐断事件。弹框关闭时移除监听。

- 捕获阶段先于冒泡阶段触发，`stopImmediatePropagation` 会阻止该事件后续所有监听器（含 document 冒泡）执行。
- 对无焦点陷阱的普通页面无副作用，现有 e2e 行为不变。

## 验证

1. `chrome://extensions/` 重新加载扩展
2. 打开带打开态弹框的 Jira 页面（如新建 Issue 弹框）
3. 唤起输入翻译框，确认焦点停留、键入内容正确进入翻译框

## 备注

浮动球菜单与划词翻译弹窗同为注入页面的浮层，若内部含可聚焦元素，在 Jira 弹框中可能有同类问题。本次仅按反馈精准修复输入翻译框，其余可后续按需处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)