### PR TITLE
fix: model compatibility (GPT-5.x/Claude), version display, and page-translation bugs

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -308,23 +308,57 @@ async function callClaudeAPI(endpoint, apiKey, model, systemPrompt, userContent,
   return data.content?.[0]?.text?.trim() || '';
 }
 
+// Normalize a model name for capability detection (strip provider prefixes like "openai/").
+function normalizeModelName(model) {
+  const name = String(model || '').toLowerCase().trim();
+  return name.includes('/') ? name.split('/').pop() : name;
+}
+
+// GPT-5.x and o-series reasoning models renamed `max_tokens` to `max_completion_tokens`
+// and only accept the default temperature (an explicit temperature returns HTTP 400).
+function isOpenAIReasoningModel(model) {
+  const name = normalizeModelName(model);
+  return /^gpt-5/.test(name) || /^o[1-9]/.test(name);
+}
+
+// Newer Claude models reject `temperature`/`top_p` ("deprecated for this model"),
+// including when reached through an OpenAI-compatible gateway. The native Claude
+// path already omits temperature, so mirror that here for any Claude model.
+function isClaudeModelName(model) {
+  const name = normalizeModelName(model);
+  return /claude|opus|sonnet|haiku|fable/.test(name);
+}
+
+// Build an OpenAI-compatible request body with model-aware parameters.
+function buildOpenAIRequestBody(model, messages, maxTokens, temperature) {
+  const body = { model, messages };
+
+  if (isOpenAIReasoningModel(model)) {
+    // GPT-5.x / o-series: new token-limit field, default temperature only.
+    body.max_completion_tokens = maxTokens;
+  } else {
+    body.max_tokens = maxTokens;
+    if (typeof temperature === 'number' && !isClaudeModelName(model)) {
+      body.temperature = temperature;
+    }
+  }
+
+  return body;
+}
+
 // Call OpenAI-compatible API
 async function callOpenAIAPI(endpoint, apiKey, model, systemPrompt, userContent, maxTokens = 4096, temperature = 0.3) {
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: userContent }
+  ];
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${apiKey}`
     },
-    body: JSON.stringify({
-      model: model,
-      messages: [
-        { role: 'system', content: systemPrompt },
-        { role: 'user', content: userContent }
-      ],
-      temperature: temperature,
-      max_tokens: maxTokens
-    })
+    body: JSON.stringify(buildOpenAIRequestBody(model, messages, maxTokens, temperature))
   });
 
   const data = await response.json().catch(() => ({}));

--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -29,6 +29,10 @@
       showTranslationError(t('extensionContextInvalidated'));
       return;
     }
+    // 如果之前的译文被“隐藏译文”开关隐藏了，再次点击“翻译整页”应先把它们重新显示出来。
+    // 否则整页已翻译、没有新块可译时会走 length === 0 分支直接返回，
+    // 译文仍处于隐藏状态，用户会觉得“再次翻译没有任何反应”。
+    revealHiddenTranslations();
     if (state.isTranslatingPage) {
       console.log('AI Translator: Already translating page');
       // 如果进度条被关闭了，重新显示它并恢复进度
@@ -143,6 +147,16 @@
     } finally {
       state.isTranslatingPage = false;
       state.translationProgress = { current: 0, total: 0 };
+    }
+  }
+
+  // 重新显示被“隐藏译文”开关隐藏的所有译文块，并同步开关状态，
+  // 使浮球菜单下次显示为“隐藏译文”。
+  function revealHiddenTranslations() {
+    const hidden = document.querySelectorAll('.ai-translator-inline-block.ai-translator-hidden');
+    hidden.forEach(el => el.classList.remove('ai-translator-hidden'));
+    if (hidden.length > 0) {
+      state.translationsVisible = true;
     }
   }
 
@@ -1006,9 +1020,13 @@
         translationEl.style.opacity = '0.85';
       } else {
         translationEl.textContent = translation;
-        // 无数学公式时，设置完整样式
+        // 无数学公式时，设置完整样式。
+        // 注意：不要在这里设置水平 margin。有些页面通过在原元素上设置
+        // `margin-left/right: auto` 让每个块居中（例如 Anthropic 文章的
+        // `.prose > *`），一旦强制 `margin: 0` 就会把译文钉在容器左侧，而原文
+        // 仍然居中，导致译文错位到左边。上下间距由 `.ai-translator-inline-block`
+        // 类（带 !important）控制。
         translationEl.style.cssText = baseStyle + `
-          margin: 0;
           padding: 0;
           box-sizing: border-box;
         `;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Academic Paper Translator",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "AI-powered translation extension with academic paper full-page translation",
   "permissions": [
     "storage",

--- a/options/options.js
+++ b/options/options.js
@@ -152,6 +152,18 @@ function applyI18n(lang) {
   
   // Update document title
   document.title = `${t('appName')} - ${t('settings')}`;
+
+  // Show the real extension version from the manifest instead of a hard-coded
+  // string, so the settings page never drifts from the released version.
+  const versionEl = document.querySelector('[data-i18n="appNameVersion"]');
+  if (versionEl) {
+    try {
+      const version = chrome.runtime.getManifest().version;
+      versionEl.textContent = `${t('appName')} v${version}`;
+    } catch (e) {
+      // getManifest() may be unavailable in some contexts; keep the i18n fallback.
+    }
+  }
 }
 
 function applyPlatformHotkeyLabels() {
@@ -567,6 +579,14 @@ function isClaudeAPI(endpoint) {
   return endpoint.includes('anthropic.com') || endpoint.includes('/v1/messages');
 }
 
+// GPT-5.x and o-series reasoning models use `max_completion_tokens` instead of
+// `max_tokens`; sending `max_tokens` to them returns HTTP 400.
+function isOpenAIReasoningModel(model) {
+  const name = String(model || '').toLowerCase().trim();
+  const shortName = name.includes('/') ? name.split('/').pop() : name;
+  return /^gpt-5/.test(shortName) || /^o[1-9]/.test(shortName);
+}
+
 // Test API connection
 async function testConnection() {
   const providerKey = elements.provider.value;
@@ -610,19 +630,26 @@ async function testConnection() {
       });
     } else {
       // Use OpenAI-compatible API format
+      const testModel = modelName || 'gpt-4.1-mini';
+      const testBody = {
+        model: testModel,
+        messages: [
+          { role: 'user', content: 'Hi' }
+        ]
+      };
+      // GPT-5.x / o-series reasoning models require max_completion_tokens.
+      if (isOpenAIReasoningModel(testModel)) {
+        testBody.max_completion_tokens = 20;
+      } else {
+        testBody.max_tokens = 20;
+      }
       response = await fetch(apiEndpoint, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${apiKey}`
         },
-        body: JSON.stringify({
-          model: modelName || 'gpt-4.1-mini',
-          messages: [
-            { role: 'user', content: 'Hi' }
-          ],
-          max_tokens: 20
-        })
+        body: JSON.stringify(testBody)
       });
     }
 


### PR DESCRIPTION
## Summary

Fixes five reported issues across the API layer, settings page, and page translation.

| # | Issue | Root cause | Fix |
|---|-------|-----------|-----|
| 1 | GPT‑5.x models fail | GPT‑5.x / o‑series renamed `max_tokens` → `max_completion_tokens` (old field → HTTP 400) | Model‑aware `buildOpenAIRequestBody`: emit `max_completion_tokens` for `gpt-5*`/`o[1-9]*`, keep `max_tokens` otherwise (+ same in Test Connection) |
| 2 | Newest Claude models fail | `opus-4-7/4-8`, `fable-5` reject `temperature` over OpenAI‑compatible gateways (`400 "deprecated for this model"`) | Omit `temperature` for any Claude model on the OpenAI path (matches the native Claude path, which never sent it); non‑Claude keeps `0.3` |
| 3 | Settings version wrong | `appNameVersion` hard‑coded `v1.0.0` in all 10 locales | `applyI18n` now reads `chrome.runtime.getManifest().version`; manifest bumped to `1.0.5` |
| 4 | Anthropic article translation misaligned left | Page centers blocks via `.prose > * { margin-left/right: auto }`; injected translation forced inline `margin: 0`, overriding centering and left‑pinning it | Removed the horizontal `margin: 0` override; vertical spacing still comes from `.ai-translator-inline-block` (`!important`) |
| 5 | Re‑translate after hide does nothing | Hide only adds `.ai-translator-hidden`; re‑translate then finds 0 untranslated blocks and returns early with translations still hidden | `translatePage()` calls new `revealHiddenTranslations()` first to un‑hide and re‑sync the float‑ball toggle |

## Files changed

- `background/background.js` — model‑aware OpenAI request builder (#1, #2)
- `options/options.js` — dynamic manifest version + reasoning‑model token field in Test Connection (#1, #3)
- `content/content-page-translation.js` — margin fix (#4) + reveal‑on‑retranslate (#5)
- `manifest.json` — version → 1.0.5 (#3)

## Test plan

- [x] `node --check` passes on all edited files
- [x] Model parameter selection unit‑tested across 16 model names (gpt‑5*, o‑series, gpt‑4o/4.1/3.5, claude‑opus/sonnet/fable, qwen)
- [x] **#4** verified in headless Chrome against the real Anthropic `.prose` CSS: source `left=480px`, old insertion `left=100px` (misaligned), new insertion `left=480px` (aligned)
- [x] **#5** verified in headless Chrome: 2/2 translations hidden → 2/2 visible after re‑translate, toggle state restored
- [ ] Manual smoke test in Chrome with a GPT‑5 / newest‑Claude key and on the Anthropic article

🤖 Generated with [Claude Code](https://claude.com/claude-code)
