### PR TITLE
fix: math placeholder reordering + batch translation misalignment

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -801,14 +801,22 @@ async function translateBatchFastWithAI(texts, targetLang, settings, delimiter =
   }
 
   // Parse by delimiter
-  const translations = content.split(delimiter).map(t => t.trim());
+  const segments = content.split(delimiter).map(t => t.trim());
 
-  // Ensure we have the same number of translations as inputs
-  while (translations.length < texts.length) {
-    translations.push('');
+  // 段数必须与输入数量一致，否则按位置回填不可靠。模型偶尔会漏掉/多打一个分隔符
+  // （或把相邻两段合并），此时若像以前那样 pad/truncate 到 texts.length，会把数量
+  // 错误“抹平”，导致整批从出错点起往后错开一位——A 段挂上 B 段的译文。
+  // 改为回退到编号法：[1][2]… 按编号精确对齐，对漏标记/乱序稳健，最坏是某段未译
+  // 而非串位。仅在极少数不匹配时多发一次请求。
+  if (segments.length !== texts.length) {
+    console.warn(
+      `AI Translator: fast-batch delimiter split produced ${segments.length} segments ` +
+      `for ${texts.length} inputs; falling back to numbered batch to avoid misaligned translations`
+    );
+    return translateBatchWithAI(texts, targetLang, settings);
   }
 
-  return translations.slice(0, texts.length);
+  return segments;
 }
 
 // Parse numbered response from AI

--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -1054,37 +1054,46 @@
       text = prefix + text;
     }
 
-    // 按占位符拆分文本，逐个插入文本节点和数学元素
-    let remaining = text;
-
+    // 建立 占位符编号 -> 数学条目 的映射，按“译文中实际出现的顺序”还原。
+    // 不能依赖 mathElements 的原始下标顺序：翻译（尤其中英语序差异）经常调换公式
+    // 前后位置，例如 “each m KV entries in C^a and C^b” → “C^a 和 C^b 中的每 m 个……”，
+    // 会把 {{3}} {{4}} 排到 {{2}} 之前。旧实现按原始顺序逐个 indexOf 并截断剩余文本，
+    // 一旦顺序被调换，靠前编号的占位符就会把靠后编号的占位符连同其间文本一起吞掉，
+    // 导致后者以字面 {{n}} 残留、且对应公式被丢弃（arxiv 页 C^a/C^b 显示为 {{3}}{{4}}）。
+    const mathByNumber = new Map();
     for (const math of mathElements) {
-      const placeholderIndex = remaining.indexOf(math.placeholder);
-      if (placeholderIndex === -1) {
-        // 占位符未找到，可能被 LLM 删除了，跳过
-        continue;
-      }
+      const m = /^\{\{(\d+)\}\}$/.exec(math.placeholder);
+      if (m) mathByNumber.set(m[1], math);
+    }
+
+    const placeholderRe = /\{\{(\d+)\}\}/g;
+    let lastIndex = 0;
+    let match;
+    while ((match = placeholderRe.exec(text)) !== null) {
+      const math = mathByNumber.get(match[1]);
+      // 未知编号（模型幻觉出的占位符）：保留为普通文本，随后随 textBefore 一并插入
+      if (!math) continue;
 
       // 添加占位符前的文本
-      const textBefore = remaining.substring(0, placeholderIndex);
+      const textBefore = text.slice(lastIndex, match.index);
       if (textBefore) {
         container.appendChild(document.createTextNode(textBefore));
       }
 
-      // 添加原始数学元素或 LaTeX 文本
+      // 还原原始数学元素或 LaTeX 文本（每次出现都独立 clone，兼容重复占位符）
       if (math.type === 'text') {
         container.appendChild(document.createTextNode(math.text));
       } else if (math.element) {
-        const mathClone = math.element.cloneNode(true);
-        container.appendChild(mathClone);
+        container.appendChild(math.element.cloneNode(true));
       }
 
-      // 更新剩余文本
-      remaining = remaining.substring(placeholderIndex + math.placeholder.length);
+      lastIndex = placeholderRe.lastIndex;
     }
 
     // 添加最后剩余的文本
-    if (remaining) {
-      container.appendChild(document.createTextNode(remaining));
+    const tail = text.slice(lastIndex);
+    if (tail) {
+      container.appendChild(document.createTextNode(tail));
     }
   }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Academic Paper Translator",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "AI-powered translation extension with academic paper full-page translation",
   "permissions": [
     "storage",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "icons": "node scripts/generate-icons.js",
     "build": "echo 'No build required - load directly in Chrome'",
-    "zip": "zip -r ai-translator.zip manifest.json background/ content/ popup/ icons/*.png -x '*.DS_Store'",
+    "zip": "rm -f ai-translator.zip && zip -r ai-translator.zip manifest.json background/ content/ i18n/ options/ popup/ icons/icon16.png icons/icon32.png icons/icon48.png icons/icon128.png icons/icon16-light.png icons/icon32-light.png icons/icon48-light.png icons/icon128-light.png -x '*.DS_Store'",
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:ui": "npx playwright test --ui",


### PR DESCRIPTION
## Summary

Fixes two page-translation correctness bugs reported on an arXiv HTML paper.

### 1. Math formulas render as literal `{{3}}` `{{4}}`
On the arXiv page, `$C^a$` and `$C^b$` showed up as literal `{{3}}` and `{{4}}` while every other formula rendered fine.

**Root cause** — [`buildTranslationContentWithMath`](content/content-page-translation.js) walked `mathElements` in their original **extraction order** and truncated the remaining text after each `indexOf` match. EN→ZH translation reorders placeholders (`each m KV entries in C^a and C^b` → `C^a 和 C^b 中的每 m 个…`, moving `{{3}}{{4}}` **before** `{{2}}`). Matching `{{2}}` first swallowed the still-pending `{{3}}{{4}}` into its preceding text node, then dropped their math clones (`indexOf` → `-1`).

**Fix** — build a `placeholder-number → math entry` map and restore by scanning the translated text in **output order** via `/\{\{(\d+)\}\}/g`, independent of extraction order. Handles reordering, duplicates, and unknown placeholders.

### 2. "Paragraph A shows paragraph B's translation" (surfaced by fast scrolling)
**Root cause** — `translateBatchFastWithAI` split the model output by delimiter, then pad/truncated to `texts.length`, silently masking delimiter miscounts (model drops/dupes/merges a separator). The positional map then shifts every block after the defect by one. Not caused by scrolling itself — the bad batch is usually in the off-screen (deferred) content, so scrolling down just **reveals** it.

**Fix** — when the delimiter split count ≠ input count, fall back to the numbered method (`parseNumberedResponse` aligns by explicit `[n]` markers, robust to dropped markers/reordering; worst case a segment is left untranslated rather than misaligned). Mirrors the guard already used on the oversized-block path.

## Also included
- Bump `manifest.json` → **1.0.6**
- Fix the `zip` script to include the previously-missing `i18n/` and `options/` directories

## Verification
Standalone reproduction of the arXiv reorder case:
- **old** → literal `{{3}}{{4}}` + dropped `C^a`/`C^b`
- **new** → all 7 formulas restored in correct ZH order, no literal placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)