### PR TITLE
chore: bump version to 1.0.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Academic Paper Translator",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "AI-powered translation extension with academic paper full-page translation",
   "permissions": [
     "storage",


### PR DESCRIPTION
Releases the fixes from #10 (reordered math placeholders + batch translation misalignment) under **1.0.7** instead of 1.0.6, since 1.0.6 was already built/distributed.

Manifest-only change: `version` 1.0.6 → 1.0.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)