### PR TITLE
fix: translate table-based layout pages (e.g. Hacker News)

### DIFF
--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -410,9 +410,11 @@
     const blockTags = ['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'LI', 'TD', 'TH', 'FIGCAPTION', 'BLOCKQUOTE', 'DT', 'DD'];
     // 内联可翻译元素 - 这些元素即使不是块级也应单独翻译
     const inlineTags = ['A', 'SPAN', 'LABEL', 'BUTTON'];
-    const skipTags = ['SCRIPT', 'STYLE', 'NOSCRIPT', 'IFRAME', 'TEXTAREA', 'INPUT', 'SELECT', 'CODE', 'PRE', 'SVG', 'CANVAS', 'KBD', 'SAMP', 'VAR', 'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TR'];
+    const skipTags = ['SCRIPT', 'STYLE', 'NOSCRIPT', 'IFRAME', 'TEXTAREA', 'INPUT', 'SELECT', 'CODE', 'PRE', 'SVG', 'CANVAS', 'KBD', 'SAMP', 'VAR'];
     // 容器元素 - 这些元素不应作为整体翻译，应递归处理子元素
-    const containerTags = ['NAV', 'UL', 'OL', 'DIV', 'SECTION', 'ARTICLE', 'ASIDE', 'HEADER', 'FOOTER', 'MAIN'];
+    // 表格标签作为容器递归下探到单元格（TD/TH 在 blockTags 中）：很多站点（如 Hacker News）
+    // 用表格做整页布局，若把 TABLE/TR 当作 skipTags 会跳过全部正文，导致“0 个可译块 → 误报页面已翻译”。
+    const containerTags = ['NAV', 'UL', 'OL', 'DIV', 'SECTION', 'ARTICLE', 'ASIDE', 'HEADER', 'FOOTER', 'MAIN', 'TABLE', 'THEAD', 'TBODY', 'TFOOT', 'TR'];
     // 用于检测代码/脚本内容的模式
     const codePatterns = [
       /^[\s\S]*<script[\s>]/i,       // 包含 <script 标签
@@ -470,6 +472,16 @@
       if (urlLength / text.length > 0.7) return true;
 
       return false;
+    }
+
+    // 检查文本是否只由数字与常见数值符号组成（数据表单元格常见，如 0.83、94.2%、±0.02、1,234）。
+    // 这类单元格翻译无意义，还会给结果表添噪，直接跳过。要求至少含一个数字，
+    // 以免误伤 "N/A"、"Method" 等含字母的表头/文本单元格。
+    function isNumericOrSymbolOnly(text) {
+      const t = (text || '').trim();
+      if (!t) return false;
+      if (!/\d/.test(t)) return false;
+      return /^[\d\s.,%±+\-*/()<>=:~×·°∓‰$€£¥–—]+$/.test(t);
     }
 
     // 检查元素是否有可翻译的子元素（用于判断是否应该递归而非整体翻译）
@@ -630,6 +642,10 @@
         if (text && text.length >= 2) {
           // 跳过看起来像代码或主要是URL的文本（排除数学占位符后判断）
           const textWithoutMath = text.replace(/\{\{\d+\}\}/g, '');
+          // 数据表单元格若只是数字/符号（如 0.83、94.2%），跳过：翻译无意义且会给结果表加噪
+          if ((tagName === 'TD' || tagName === 'TH') && isNumericOrSymbolOnly(textWithoutMath)) {
+            return;
+          }
           if (textWithoutMath && (looksLikeCode(textWithoutMath) || isMainlyUrl(textWithoutMath))) {
             // 递归处理子元素，可能有非代码/非URL的部分
             for (const child of element.children) {
@@ -1158,12 +1174,15 @@
       inlineTarget.appendChild(translationEl);
     } else {
       // 对于非水平 flex 布局（如侧边栏），插入为同级元素
-      const translationEl = document.createElement(element.tagName);
+      // 表格单元格例外：译文要插到单元格【内部】，插一个兄弟 <td> 会给整行多加一列、撑破表格网格
+      const isTableCell = element.tagName === 'TD' || element.tagName === 'TH';
+      const translationEl = document.createElement(isTableCell ? 'div' : element.tagName);
 
       // 复制原始元素的类名，保留页面的 CSS 样式（如 ltx_p 用于 MathML 内联显示）
       // 然后添加我们的标记类
       // 需要移除位置相关的类，避免破坏布局（如 absolute, fixed, inset-* 等）
-      if (element.className) {
+      // 单元格不复制类名：避免把列宽/对齐等单元格专属样式带到译文块上
+      if (element.className && !isTableCell) {
         const positionClasses = /\b(absolute|fixed|sticky|relative|inset-\S*|top-\S*|bottom-\S*|left-\S*|right-\S*|z-\S*)\b/g;
         translationEl.className = element.className
           .replace('ai-translator-translated', '')
@@ -1217,6 +1236,10 @@
           box-sizing: border-box;
         `;
         element.appendChild(internalTranslation);
+      } else if (isTableCell) {
+        // 表格单元格：译文作为块级子节点追加到单元格【内部】，显示在原内容下方，保持网格不变。
+        // 用 <div>（而非 <td>）避免 td 内嵌 td 的非法结构。
+        element.appendChild(translationEl);
       } else {
         // 插入到原元素后面
         element.after(translationEl);
@@ -1542,4 +1565,6 @@
   ctx.isHorizontalFlexParent = isHorizontalFlexParent;
   ctx.getInlineTranslationTarget = getInlineTranslationTarget;
   ctx.getTextOffsetLeft = getTextOffsetLeft;
+  ctx.collectTranslatableBlocks = collectTranslatableBlocks;
+  ctx.insertTranslationBlock = insertTranslationBlock;
 })();

--- a/test/e2e/table-translation.spec.js
+++ b/test/e2e/table-translation.spec.js
@@ -1,0 +1,88 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+// Focused DOM unit test of the REAL collectTranslatableBlocks + insertTranslationBlock
+// functions, loaded straight from source into a plain headless page (no extension, network,
+// or display needed). Guards the Hacker-News table-layout regression:
+//   - sites that use tables for layout must produce translatable blocks (previously TABLE/TR
+//     were in skipTags → 0 blocks → page falsely reported "already translated");
+//   - a cell's translation is inserted INSIDE the cell as a <div>, never as a sibling <td>
+//     (a sibling cell would add a phantom column and break the grid);
+//   - pure-numeric/symbol data cells (0.83, 94.2%, ±0.02) are skipped.
+const ROOT = path.join(__dirname, '..', '..');
+const SCRIPTS = [
+  path.join(ROOT, 'i18n/messages.js'),
+  path.join(ROOT, 'content/content-bootstrap.js'),
+  path.join(ROOT, 'content/content-page-translation.js'),
+];
+
+const FIXTURE_HTML = `<!doctype html><html><head><meta charset="utf-8"></head><body>
+  <table id="layout-table" border="0">
+    <tr><td id="layout-cell">Hacker News style comment text lives inside a table cell.</td></tr>
+  </table>
+  <table id="data-table" border="1">
+    <tr>
+      <th id="hdr-text">Method description column</th>
+      <td id="num-a">0.83</td>
+      <td id="num-b">94.2%</td>
+    </tr>
+    <tr>
+      <td id="cell-text">Descriptive result label here</td>
+      <td id="num-c">±0.02</td>
+      <td id="num-d">1,234</td>
+    </tr>
+  </table>
+</body></html>`;
+
+test('table layout: cells translate inside the cell, grid intact, numeric cells skipped', async ({ page }) => {
+  await page.setContent(FIXTURE_HTML, { waitUntil: 'load' });
+  for (const s of SCRIPTS) await page.addScriptTag({ path: s });
+
+  const result = await page.evaluate(() => {
+    const ctx = window.AI_TRANSLATOR_CONTENT;
+    const blocks = ctx.collectTranslatableBlocks(document.body);
+    const collectedIds = blocks.map((b) => b.element.id).filter(Boolean).sort();
+
+    // Run the real insertion for every collected block.
+    blocks.forEach((b) => ctx.insertTranslationBlock(b, '[T] ' + b.text));
+
+    const info = (id) => {
+      const el = document.getElementById(id);
+      const inner = el.querySelector('.ai-translator-inline-block');
+      return {
+        translated: el.classList.contains('ai-translator-translated'),
+        innerTag: inner ? inner.tagName : null
+      };
+    };
+
+    return {
+      collectedIds,
+      cellText: info('cell-text'),
+      hdrText: info('hdr-text'),
+      layoutCell: info('layout-cell'),
+      numA: info('num-a'),
+      row1Cells: document.querySelectorAll('#data-table tr:nth-child(1) > th, #data-table tr:nth-child(1) > td').length,
+      row2Cells: document.querySelectorAll('#data-table tr:nth-child(2) > td').length
+    };
+  });
+
+  // 1) Original bug: table content is collected & translated (not "0 blocks / already translated").
+  expect(result.collectedIds).toContain('layout-cell');
+  expect(result.collectedIds).toContain('hdr-text');
+  expect(result.collectedIds).toContain('cell-text');
+  expect(result.layoutCell.translated).toBe(true);
+
+  // 2) Pure numeric/symbol data cells are skipped (no noise).
+  for (const id of ['num-a', 'num-b', 'num-c', 'num-d']) {
+    expect(result.collectedIds).not.toContain(id);
+  }
+  expect(result.numA.translated).toBe(false);
+  expect(result.numA.innerTag).toBeNull();
+
+  // 3) Translation is inserted INSIDE the cell as a <div>, and the grid is intact
+  //    (no sibling <td> added — the sibling-cell bug would inflate these counts).
+  expect(result.cellText.innerTag).toBe('DIV');
+  expect(result.hdrText.innerTag).toBe('DIV');
+  expect(result.row1Cells).toBe(3);
+  expect(result.row2Cells).toBe(3);
+});


### PR DESCRIPTION
## Problem

On table-based-layout sites (e.g. [Hacker News](https://news.ycombinator.com/item?id=48837877)), clicking **Translate full page** immediately shows "page already translated" without translating anything.

## Root cause

`collectTranslatableBlocks` had `TABLE/THEAD/TBODY/TFOOT/TR` in `skipTags`, so it skipped **all** table content. HN wraps its entire page (title + every comment) in tables, so the collector returned **0 blocks**, `translatePage` fell through the `length === 0` branch, and `showAlreadyTranslatedMessage()` fired — no request was ever sent.

`TD`/`TH` were listed in `blockTags` the whole time (intent: translate cells), but they were unreachable because their table ancestors were skipped — so table translation had **never** worked.

The table tags were originally added to `skipTags` (`f0f0d77`) as a blunt workaround for a real rendering bug: translating a data cell inserted a **sibling `<td>`** (`insertTranslationBlock` creates a same-tag element and calls `element.after()`), which adds a phantom column and breaks the grid.

> Note: the `hn.js` `el.className.split is not a function` console error is **unrelated** — it's HN's own global click handler choking on the `SVGAnimatedString` className of our injected SVG icons. It does not affect translation and is left for a separate change.

## Fix

- Move `TABLE/THEAD/TBODY/TFOOT/TR` from `skipTags` → `containerTags` so the collector recurses into cells (`TD`/`TH` already in `blockTags`).
- `insertTranslationBlock`: for `TD`/`TH`, append the translation as a block `<div>` **inside** the cell instead of a sibling `<td>` — keeps the grid intact and fixes the underlying rendering bug the `skipTags` workaround was hiding.
- Skip pure numeric/symbol data cells (`0.83`, `94.2%`, `±0.02`) so results tables in papers/specs aren't cluttered with pointless translations.
- Expose `collectTranslatableBlocks`/`insertTranslationBlock` on `ctx` for headless DOM testing (consistent with the file's existing `ctx` exposures).

Math in cells is unaffected — the existing `{{n}}` placeholder mechanism still preserves formulas.

## Testing

New `test/e2e/table-translation.spec.js` drives the **real** functions in a headless DOM (no extension/network/display needed) and asserts:

- ✅ table cells (layout cell, header, text cell) are collected & translated — the original 0-blocks bug is fixed
- ✅ pure numeric/symbol cells (`0.83`, `94.2%`, `±0.02`, `1,234`) are skipped
- ✅ translation is inserted as a `<div>` **inside** the cell, and row cell counts stay unchanged (no phantom column)

```
1 passed (2.0s)
```

Numeric-boundary spot check (no over-skipping): `N/A`, `GPT-4`, `Table 1`, `ResNet-50`, `3 hours ago` are all kept; `0.83 / 94.2% / ±0.02 / $300 / <0.001` are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
