### PR TITLE
chore: release 1.1.0 — rename to AI Translator + localized store metadata

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "AI Translator",
+    "description": "Extension name shown in Chrome and the Web Store."
+  },
+  "appDescription": {
+    "message": "Kostenlose, sichere KI-Übersetzung ohne Zwischenserver. Webseiten, Fachartikel (Formeln/LaTeX erhalten), Live-YouTube-Untertitel.",
+    "description": "Extension description shown in Chrome and the Web Store (<=132 chars)."
+  }
+}

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "AI Translator",
+    "description": "Extension name shown in Chrome and the Web Store."
+  },
+  "appDescription": {
+    "message": "Free, secure AI translation with no middleman. Web pages, academic papers (math/LaTeX preserved), and real-time YouTube captions.",
+    "description": "Extension description shown in Chrome and the Web Store (<=132 chars)."
+  }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "AI Translator",
+    "description": "Extension name shown in Chrome and the Web Store."
+  },
+  "appDescription": {
+    "message": "Traducción IA gratuita y segura, sin intermediarios. Webs, artículos académicos (fórmulas/LaTeX intactas), subtítulos de YouTube.",
+    "description": "Extension description shown in Chrome and the Web Store (<=132 chars)."
+  }
+}

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "AI Translator",
+    "description": "Extension name shown in Chrome and the Web Store."
+  },
+  "appDescription": {
+    "message": "Traduction IA gratuite, sûre, sans intermédiaire. Pages web, articles scientifiques (maths/LaTeX intacts), sous-titres YouTube.",
+    "description": "Extension description shown in Chrome and the Web Store (<=132 chars)."
+  }
+}

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "AI Translator",
+    "description": "Extension name shown in Chrome and the Web Store."
+  },
+  "appDescription": {
+    "message": "無料・安全・中継サーバーなしのAI翻訳。ウェブページ、学術論文(数式/LaTeXを保持)、YouTubeのリアルタイム字幕に対応。",
+    "description": "Extension description shown in Chrome and the Web Store (<=132 chars)."
+  }
+}

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "AI Translator",
+    "description": "Extension name shown in Chrome and the Web Store."
+  },
+  "appDescription": {
+    "message": "무료·안전·중계 서버 없는 AI 번역. 웹페이지, 학술 논문(수식/LaTeX 보존), 실시간 YouTube 자막 지원.",
+    "description": "Extension description shown in Chrome and the Web Store (<=132 chars)."
+  }
+}

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "AI Translator",
+    "description": "Extension name shown in Chrome and the Web Store."
+  },
+  "appDescription": {
+    "message": "Tradução IA grátis e segura, sem intermediário. Páginas web, artigos acadêmicos (fórmulas/LaTeX preservadas), legendas do YouTube.",
+    "description": "Extension description shown in Chrome and the Web Store (<=132 chars)."
+  }
+}

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "AI Translator",
+    "description": "Extension name shown in Chrome and the Web Store."
+  },
+  "appDescription": {
+    "message": "Бесплатный безопасный ИИ-перевод без посредников. Веб-страницы, научные статьи (формулы/LaTeX сохранены), субтитры YouTube.",
+    "description": "Extension description shown in Chrome and the Web Store (<=132 chars)."
+  }
+}

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "AI Translator",
+    "description": "Extension name shown in Chrome and the Web Store."
+  },
+  "appDescription": {
+    "message": "免费、安全、无中间服务器的 AI 翻译:网页、学术论文(保留数学公式/LaTeX)、YouTube 实时字幕。",
+    "description": "Extension description shown in Chrome and the Web Store (<=132 chars)."
+  }
+}

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "AI Translator",
+    "description": "Extension name shown in Chrome and the Web Store."
+  },
+  "appDescription": {
+    "message": "免費、安全、無中間伺服器的 AI 翻譯:網頁、學術論文(保留數學公式/LaTeX)、YouTube 即時字幕。",
+    "description": "Extension description shown in Chrome and the Web Store (<=132 chars)."
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "AI Academic Paper Translator",
-  "version": "1.0.8",
-  "description": "AI-powered translation extension with academic paper full-page translation",
+  "name": "__MSG_appName__",
+  "version": "1.1.0",
+  "description": "__MSG_appDescription__",
+  "default_locale": "en",
   "permissions": [
     "storage",
     "activeTab",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "icons": "node scripts/generate-icons.js",
     "build": "echo 'No build required - load directly in Chrome'",
-    "zip": "rm -f ai-translator.zip && zip -r ai-translator.zip manifest.json background/ content/ i18n/ options/ popup/ icons/icon16.png icons/icon32.png icons/icon48.png icons/icon128.png icons/icon16-light.png icons/icon32-light.png icons/icon48-light.png icons/icon128-light.png -x '*.DS_Store'",
+    "zip": "rm -f ai-translator.zip && zip -r ai-translator.zip manifest.json _locales/ background/ content/ i18n/ options/ popup/ icons/icon16.png icons/icon32.png icons/icon48.png icons/icon128.png icons/icon16-light.png icons/icon32-light.png icons/icon48-light.png icons/icon128-light.png -x '*.DS_Store'",
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:ui": "npx playwright test --ui",


### PR DESCRIPTION
Release metadata for **v1.1.0** (the YouTube caption translation rework, #14).

## Version
- `1.0.8` → `1.1.0`.

## Rebrand (drop the stale "academic paper" framing)
- Name → **AI Translator** (matches the in-app name used across all locales).
- New description positions the extension by what it is, not how it's built:
  > Free, secure AI translation with no middleman. Web pages, academic papers (math/LaTeX preserved), and real-time YouTube captions.
- **Free · secure · no middleman** — the browser calls the AI directly with your own key; no third-party relay server.
- Both **OpenAI-compatible** and **native Anthropic/Claude** APIs are supported (`isClaudeAPI` / `callClaudeAPI`), so the old "OpenAI-compatible API" technical detail was dropped.
- Keeps the standout strengths front-and-centre: academic paper translation with **math/LaTeX preserved**, plus real-time YouTube captions.

## Localized store metadata (i18n)
- Adds Chrome `_locales/` with `default_locale: en`; the manifest now uses `__MSG_appName__` / `__MSG_appDescription__`.
- Localized descriptions for **en, zh_CN, zh_TW, ja, ko, fr, de, es, pt_BR, ru** (each ≤132 chars) — so each region sees a native description in Chrome and the Web Store.
- `_locales/` is now included in the `npm run zip` build.

No runtime code changes; the packaged zip was rebuilt and verified (manifest resolves per-locale, all 10 locale files present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
