### PR TITLE
fix: 跳过纯公式块，避免全文翻译后公式重复渲染

### DIFF
--- a/content/content-hover-translation.js
+++ b/content/content-hover-translation.js
@@ -333,6 +333,12 @@
     const { text, mathElements } = getBlockText(block);
     if (!text || text.length < 2 || text.length > 2000) return;
 
+    // 排除公式占位符后没有正文：整块只是一条公式（如 arXiv 行间公式所在的 <td>，
+    // 它本身不在 MATH_CONTAINER_SELECTOR 内，isValidBlock 拦不住），翻译无意义，
+    // 且译文还原占位符后会把同一条公式在原文下方再渲染一遍。
+    // 注意长度判断挡不住：占位符 "{{1}}" 有 5 个字符。
+    if (!text.replace(/\{\{\d+\}\}/g, '').trim()) return;
+
     const targetLang = ctx.getEffectiveTargetLang ? ctx.getEffectiveTargetLang() : settings.targetLang;
     const cacheKey = buildCacheKey(text, targetLang);
     const cached = getCachedTranslation(block, cacheKey);

--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -623,7 +623,9 @@
         const { text, mathElements } = getTextWithMathPlaceholders(element);
         if (text && text.length >= 2 && text.length <= 500) {
           // 跳过看起来像代码或主要是URL的文本
-          const textWithoutMath = text.replace(/\{\{\d+\}\}/g, '');
+          // 这里要 trim：只含公式的元素排除占位符后会剩下空白（如 "{{1}} {{2}}"），
+          // 不 trim 会被当成有正文，进而把纯公式送去翻译。
+          const textWithoutMath = text.replace(/\{\{\d+\}\}/g, '').trim();
           if (textWithoutMath && !looksLikeCode(textWithoutMath) && !isMainlyUrl(textWithoutMath)) {
             blocks.push({
               element: element,
@@ -641,7 +643,16 @@
         const { text, mathElements } = getTextWithMathPlaceholders(element);
         if (text && text.length >= 2) {
           // 跳过看起来像代码或主要是URL的文本（排除数学占位符后判断）
-          const textWithoutMath = text.replace(/\{\{\d+\}\}/g, '');
+          const textWithoutMath = text.replace(/\{\{\d+\}\}/g, '').trim();
+
+          // 排除公式占位符后没有任何正文：整个块就是一条公式，跳过。
+          // 典型是 arXiv/LaTeXML 的行间公式——公式包在 <table class="ltx_equation"> 里，
+          // 遍历下探到 <td class="ltx_eqn_cell"> 时 text 只有 "{{1}}"。
+          // 若不跳过，"{{1}}" 会被送去翻译，模型原样返回后再按占位符 clone 回原 <math>，
+          // 结果是同一条公式在原文下方又渲染一遍（公式出现两遍）。
+          // 这里 return 而不递归：块内只有公式，子元素会被 MATH_CONTAINER_SELECTOR 拦下，递归没有意义。
+          if (!textWithoutMath) return;
+
           // 数据表单元格若只是数字/符号（如 0.83、94.2%），跳过：翻译无意义且会给结果表加噪
           if ((tagName === 'TD' || tagName === 'TH') && isNumericOrSymbolOnly(textWithoutMath)) {
             return;
@@ -1006,7 +1017,14 @@
   async function shouldSkipTranslation(block, translation) {
     const normalizedOriginal = normalizeComparableText(block.text);
     const normalizedTranslation = normalizeComparableText(translation);
-    if (normalizedOriginal && normalizedOriginal === normalizedTranslation) {
+
+    // 原文除公式占位符/空白外没有任何正文时，一律不插译文（兜底不变量）。
+    // normalizeComparableText 会剥掉 {{N}}，所以纯公式块在这里归一化成空串；
+    // 早先写作 `normalizedOriginal && normalizedOriginal === normalizedTranslation`，
+    // 空串是 falsy，同一性守卫对纯公式块从不生效，公式因而被重复渲染。
+    if (!normalizedOriginal) return true;
+
+    if (normalizedOriginal === normalizedTranslation) {
       return true;
     }
 


### PR DESCRIPTION
## 问题

全文翻译 arXiv 等论文页后，行间公式会在原公式正下方**重复渲染一遍**（两遍内容完全相同）。

复现页：https://arxiv.org/html/2507.20534v2

## 根因

回归自 `d487e3b` *fix: translate table-based layout pages (e.g. Hacker News)*。

该提交把 `TABLE/THEAD/TBODY/TFOOT/TR` 从 `skipTags` 移入 `containerTags`，用于修复 Hacker News 这类拿表格做整页布局的站点。副作用是遍历开始**下探进公式表格**——arXiv/LaTeXML 的行间公式整体包在 `<table class="ltx_equation ltx_eqn_table">` 里：

```html
<table class="ltx_equation ltx_eqn_table">
  <tr><td class="ltx_eqn_cell ltx_align_center"><math class="ltx_Math" display="block">…</math></td></tr>
```

需要说明的是，此前"遇到公式自动跳过"**并不是一条专门的公式跳过逻辑**，而是"跳过所有表格"的副作用。

完整链路：

1. 下探到 `<td class="ltx_eqn_cell">`（`TD` 在 `blockTags` 里）
2. 该单元格只含 `<math>`，`getTextWithMathPlaceholders` 把它换成占位符 → `block.text` 是纯 `"{{1}}"`
3. `collectTranslatableBlocks` 缺少"剥掉占位符后无正文则跳过"的判断：`text.length >= 2` 通过（`"{{1}}"` 是 5 个字符），而 `if (textWithoutMath && ...)` 因空串短路，于是直接 `blocks.push`
4. 兜底也拦不住：`shouldSkipTranslation` 的同一性守卫写作 `normalizedOriginal && normalizedOriginal === normalizedTranslation`，但 `normalizeComparableText` 会剥掉 `{{N}}`，纯公式块归一化成**空串（falsy）**，守卫对它从不生效；语言检测同样因 `getLanguageDetectionText` 剥占位符后不足 4 字符而返回 false
5. `buildTranslationContentWithMath` 按占位符 `cloneNode` 还原原 `<math>` → 同一条公式被渲染第二遍

## 改动

修在通用层而非只针对表格——`<p>` 里只放一条 MathJax/KaTeX 公式同样会重复。

- **`collectTranslatableBlocks` 块级分支**：新增 `if (!textWithoutMath) return;`。用 `return` 而非递归，因为块内只有公式，子元素本来就会被 `MATH_CONTAINER_SELECTOR` 拦下
- **内联分支**：`textWithoutMath` 补 `.trim()`。多公式块（`"{{1}} {{2}}"`）剥掉占位符后剩一个空格是 truthy，旧代码会误判为有正文
- **`shouldSkipTranslation`**：新增兜底不变量 `if (!normalizedOriginal) return true;`
- **`translateHoverBlock`**（悬停翻译）：同类漏洞。公式所在的 `<td>` 自身不在 `MATH_CONTAINER_SELECTOR` 内，`isValidBlock` 拦不住；`length < 2` 也挡不住 5 字符的占位符。补同样的守卫

## 验证

**真实页面逐块比对**：无头 Chromium 加载真实 HTML，注入 content 脚本调 `collectTranslatableBlocks(document.body)`，对改动前后的块做指纹 diff。

| 页面 | before | after | 非公式块丢失 | 新增 |
|---|---|---|---|---|
| arXiv 2507.20534v2 | 830（13 个纯公式块） | 817（0 个纯公式块） | **0** | **0** |
| Hacker News | 65 | 65 | **0** | **0** |

恰好去掉 13 个纯公式块，其余一个不少；39 个"行内公式 + 正文"的段落完整保留。Hacker News 65 → 65，说明 `d487e3b` 的表格布局修复未受影响。

**e2e**：`table-translation.spec.js` + `hover-translation.spec.js` 共 **17 个用例全部通过**，含 `selection translation preserves MathML elements` 与 `selection translation avoids inserting into math containers`。

> 附注：`page-translation-inline-skip.spec.js` 目前超时失败，但已用 `git stash` 在干净 `main` 上复现，属**既有失败**，与本 PR 无关（疑似其 mock server 的分隔符 `<<<>>>` 与代码真实 `DELIMITER` 不一致），另行修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)