### PR TITLE
fix(test): repair page-translation-inline-skip by deriving the mock's batch delimiter from the prompt

### DIFF
--- a/test/e2e/page-translation-inline-skip.spec.js
+++ b/test/e2e/page-translation-inline-skip.spec.js
@@ -2,7 +2,23 @@ const { test, expect } = require('./fixtures');
 const { setExtensionSettings, triggerPageTranslation } = require('./helpers');
 const http = require('http');
 
+// Page translation uses the fast-batch path: blocks are joined with the DELIMITER constant
+// from content/content-page-translation.js, and the model is told to separate the
+// translations with that same delimiter (FAST_BATCH_PROMPT in background/background.js).
+// The mock must honor that contract, so it recovers the delimiter from the system prompt of
+// the request it actually receives instead of hardcoding a copy that can drift out of sync.
+//
+// Getting this wrong does NOT fail loudly: an unsegmented echo still carries the delimiters
+// through, so the segment count still matches and background.js never falls back to the
+// numbered format — but every segment after the first comes back byte-identical to its
+// source, and shouldSkipTranslation() then silently drops it as "already translated".
+const PROMPT_DELIMITER_RE = /segments are separated by "([^"]+)"/;
+
 function startMockOpenAIServer() {
+  // One entry per request that took the fast-batch path, so the test can assert the mock
+  // really spoke the delimiter protocol rather than falling through to the single-text path.
+  const fastBatchRequests = [];
+
   return new Promise((resolve) => {
     const server = http.createServer((req, res) => {
       if (req.method !== 'POST') {
@@ -17,17 +33,21 @@ function startMockOpenAIServer() {
       });
       req.on('end', () => {
         let content = '';
+        let systemPrompt = '';
         try {
           const data = JSON.parse(body);
-          content = data?.messages?.[data.messages.length - 1]?.content || '';
+          const messages = data?.messages || [];
+          content = messages[messages.length - 1]?.content || '';
+          systemPrompt = messages.find((m) => m?.role === 'system')?.content || '';
         } catch {
           content = '';
         }
 
-        const delimiter = '<<<>>>';
-        if (content.includes(delimiter)) {
-          content = content
-            .split(delimiter)
+        const delimiter = systemPrompt.match(PROMPT_DELIMITER_RE)?.[1];
+        if (delimiter) {
+          const segments = content.split(delimiter);
+          fastBatchRequests.push({ delimiter, segmentCount: segments.length });
+          content = segments
             .map((segment) => (segment ? `[T] ${segment}` : segment))
             .join(delimiter);
         } else if (content) {
@@ -46,6 +66,7 @@ function startMockOpenAIServer() {
       const { port } = server.address();
       resolve({
         server,
+        fastBatchRequests,
         endpoint: `http://127.0.0.1:${port}/v1/chat/completions`
       });
     });
@@ -53,7 +74,7 @@ function startMockOpenAIServer() {
 }
 
 test('page translation skips blocks with inline translation', async ({ page }) => {
-  const { server, endpoint } = await startMockOpenAIServer();
+  const { server, endpoint, fastBatchRequests } = await startMockOpenAIServer();
 
   try {
     await setExtensionSettings(page, {
@@ -88,6 +109,15 @@ test('page translation skips blocks with inline translation', async ({ page }) =
     await page.keyboard.up('Shift');
 
     await triggerPageTranslation(page);
+
+    // Fail fast if the prompt wording drifted and the delimiter could no longer be
+    // recovered; the symptom would otherwise be an unexplained timeout on the wait below.
+    await expect
+      .poll(() => fastBatchRequests.length, {
+        timeout: 15000,
+        message: 'mock never recognized a fast-batch request (delimiter not found in system prompt)'
+      })
+      .toBeGreaterThan(0);
 
     await page.waitForFunction(() => {
       const el = document.getElementById('inline-para-two');


### PR DESCRIPTION
## Problem

`test/e2e/page-translation-inline-skip.spec.js` has been failing with a 60s timeout on a clean `main` (verified with `git stash` — not caused by any working-tree changes). It hangs waiting for `#inline-para-two` to gain the `ai-translator-translated` class.

## Root cause

The spec's `startMockOpenAIServer()` split request content on `'<<<>>>'`, but the real fast-batch delimiter is `const DELIMITER = '⟪⟫⟪⟫⟪⟫'` in `content/content-page-translation.js`.

`'<<<>>>'` is the stale value that was removed from `content-youtube-captions.js` in 3913c25 (the LLM treated it as markup and dropped it). The source moved; this spec did not.

**The mismatch fails silently, and not in the obvious way.** It would be reasonable to assume the segment count mismatches and the batch gets dropped or falls back to the numbered format — that is *not* what happens. Instrumenting the mock and the service worker showed:

```
system: ...Input segments are separated by "⟪⟫⟪⟫⟪⟫"...
user:   Example Domain⟪⟫⟪⟫⟪⟫This domain is for use...⟪⟫⟪⟫⟪⟫Learn more⟪⟫⟪⟫⟪⟫Inline translation paragraph two.
reply:  [T] Example Domain⟪⟫⟪⟫⟪⟫This domain is for use...⟪⟫⟪⟫⟪⟫Learn more⟪⟫⟪⟫⟪⟫Inline translation paragraph two.
```

The mock does not recognise the delimiter, so it prefixes the whole blob with a single `[T] ` — but the echo still carries the real delimiters through. So:

1. `translateBatchFastWithAI` splits the reply into exactly as many segments as it sent (4 == 4), the count guard never trips, and **no fallback to the numbered format occurs** (confirmed: no service-worker warning).
2. Every segment *after the first* comes back byte-identical to its source.
3. `shouldSkipTranslation()` drops each one as "already in the target language" — no log, no error, just a block that is never translated.

## Fix

The mock now recovers the delimiter from the system prompt of the request it actually receives — `FAST_BATCH_PROMPT` states `Input segments are separated by "<delimiter>"` — so **no second hardcoded copy is left to drift**.

It also records the fast-batch requests it recognised, and the spec asserts via `expect.poll` that at least one was seen *before* entering the long wait. If the prompt wording ever changes, this fails in 15s with a clear message instead of an unexplained 60s timeout.

## Verification

Beyond the test simply passing (**2.9s**, was a 60s timeout), two checks that the fix is real and the test is not vacuous:

- **Drift resistance** — temporarily setting the source `DELIMITER` to `'###SEG###'` keeps the test green, i.e. the mock genuinely follows the source constant rather than a copy.
- **Mutation test** — removing the `ai-translator-inline-source` guard from `collectTranslatableBlocks` alone still passes, because `insertTranslationBlock` carries a second guard. Removing *both* makes the test fail on the `not.toHaveClass` assertion, so the test does detect the regression it guards.

`page-translation-inline-skip` + `table-translation` + `hover-translation`: **18 passed** (was 17 passing + 1 hanging).

Product code is untouched — this changes one test file only.

## Note for a separate change

The silent-drop path is a product-side blind spot, not just a test artifact: when a model legitimately echoes a segment unchanged, the extension discards it with no diagnostic. That is correct behaviour for same-language text, but indistinguishable from a broken batch. Worth considering a debug-level log there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
