### PR TITLE
fix(api): adapt to current OpenAI/Anthropic/Gemini model lineups, and stop duplicating the rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,11 @@ AI Translator is a Chrome Extension (Manifest V3) that translates web content us
 ## Commands
 
 ```bash
-npm run icons    # Generate extension icons (requires canvas package)
-npm run zip      # Create distributable zip file
+npm run icons      # Generate extension icons (requires canvas package)
+npm run zip        # Create distributable zip file
+npm run test:unit  # Fast, no browser — API compatibility rules (test/unit/)
+npm run test:e2e   # Playwright, loads the extension in Chrome (test/e2e/)
+npm test           # Both
 ```
 
 No build step required - the extension loads directly in Chrome as an unpacked extension.
@@ -57,10 +60,34 @@ No build step required - the extension loads directly in Chrome as an unpacked e
 
 ### API Compatibility
 
-Works with any OpenAI Chat Completions-compatible API:
-- OpenAI, Azure OpenAI, Claude (via compatible endpoints), Ollama, LM Studio
+Works with any OpenAI Chat Completions-compatible API, plus Anthropic's native
+Messages API:
+- OpenAI, Anthropic, Google Gemini, DeepSeek, OpenRouter, Ollama, LM Studio
 - Request format: `{model, messages, temperature, max_tokens}`
-- Response: `{choices[0].message.content}`
+- Response: `{choices[0].message.content}`, or `{content[0].text}` for Anthropic
+
+**All of it lives in `shared/api-compat.js`** — the provider catalog, every
+per-model parameter rule, request-body construction, and vendor error parsing.
+Both the service worker (`import '../shared/api-compat.js'`) and the options
+page (`<script src="../shared/api-compat.js">`) consume it, so the "test
+connection" button sends exactly the request translation will send.
+
+When a vendor ships a new model generation, `shared/api-compat.js` should be
+the only file that changes. Do not reimplement these checks in a caller —
+`npm run test:unit` fails if `background.js` or `options.js` redeclares them.
+New top-level directories also need adding to the `zip` script in
+`package.json`, which the same suite asserts.
+
+Parameters are model-dependent and change between generations. Current rules:
+- `gpt-5`+ and `o1`+ use `max_completion_tokens`, never `temperature`
+- `reasoning_effort` floor is `'minimal'` up to gpt-5.5, `'none'` from gpt-5.6
+  (which removed `'minimal'` outright)
+- Gemini 3+ must not be sent `temperature` (Google's guidance: keep the 1.0
+  default; lowering it can cause looping)
+- Claude models reject `temperature`, including behind an OpenAI-compatible
+  gateway
+- Models that bill hidden reasoning/thinking tokens get a floor on the output
+  budget, or short calls return empty text with `finish_reason: "length"`
 
 ## Bug Fixing Guidelines
 
@@ -82,7 +109,7 @@ Follow this process when fixing bugs:
 
 ```javascript
 apiEndpoint: 'https://api.openai.com/v1/chat/completions'
-modelName: 'gpt-4o-mini'
-targetLang: 'zh-CN'
-theme: 'dark'
+modelName: 'gpt-4.1-mini'
+targetLang: ''        // empty = follow browser language
+theme: 'light'
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,14 @@ npm run icons      # Generate extension icons (requires canvas package)
 npm run zip        # Create distributable zip file
 npm run test:unit  # Fast, no browser — API compatibility rules (test/unit/)
 npm run test:e2e   # Playwright, loads the extension in Chrome (test/e2e/)
-npm test           # Both
+npm run test:headed # Same, but with a visible window (HEADED=1)
+npm test           # test:unit + test:e2e
 ```
+
+E2E runs headless by default, so it no longer steals window focus and the
+pointer. That needs `channel: 'chromium'` in `test/e2e/fixtures.js` — the
+bundled Playwright build still cannot load an unpacked extension headless,
+only Chrome's newer headless shell can.
 
 No build step required - the extension loads directly in Chrome as an unpacked extension.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cd translator
 3. Fill in API configuration:
    - **API Endpoint**: e.g., `https://api.openai.com/v1/chat/completions`
    - **API Key**: Your API key
-   - **Model Name**: e.g., `gpt-4o-mini`
+   - **Model Name**: e.g., `gpt-4.1-mini` (pick from the dropdown, or type any model your endpoint serves)
 4. Select target translation language
 5. Click "Save Settings"
 
@@ -270,7 +270,7 @@ cd translator
 3. 填写 API 配置：
    - **API 地址**: 如 `https://api.openai.com/v1/chat/completions`
    - **API Key**: 你的 API 密钥
-   - **模型名称**: 如 `gpt-4o-mini`
+   - **模型名称**: 如 `gpt-4.1-mini`（可从下拉列表选择，也可直接填写你的接口支持的任意模型）
 4. 选择目标翻译语言
 5. 点击「保存设置」
 

--- a/background/background.js
+++ b/background/background.js
@@ -1,4 +1,5 @@
 // AI Translator Background Script
+import '../shared/api-compat.js';
 import '../i18n/messages.js';
 import * as comicClient from './comic-client.js';
 import * as pdfClient from './pdf-client.js';
@@ -323,237 +324,55 @@ async function refreshPdfMenuVisibility(enabled) {
     .catch(() => {});
 }
 
-// Detect if the API endpoint is Anthropic Claude API
-function isClaudeAPI(endpoint) {
-  if (!endpoint) return false;
-  // Check for Anthropic domain or /v1/messages path
-  return endpoint.includes('anthropic.com') || endpoint.includes('/v1/messages');
-}
+// Every provider/model shape decision lives in shared/api-compat.js so the
+// options page's connection test exercises the identical request.
+const {
+  isClaudeAPI,
+  openAIHeaders,
+  claudeHeaders,
+  buildOpenAIRequestBody,
+  buildClaudeRequestBody,
+  readAPIResponse
+} = globalThis.APICompat;
 
-// Parse API error from response data (handles different vendor formats)
-function parseAPIError(data, httpStatus) {
-  // Check for error field in response body (OpenAI, OpenRouter, etc.)
-  if (data?.error) {
-    const error = data.error;
-    // OpenAI/OpenRouter format: {"error": {"message": "...", "code": ...}}
-    if (typeof error === 'object') {
-      const message = error.message || error.msg || JSON.stringify(error);
-      const code = error.code || error.type || httpStatus;
-      return { isError: true, message, code };
-    }
-    // Simple string error
-    if (typeof error === 'string') {
-      return { isError: true, message: error, code: httpStatus };
-    }
-  }
+// Issue one translation request and return its text, or throw with a
+// user-facing message. Both vendors are handled the same way: some APIs report
+// failures with HTTP 200 and an error payload, so the body is always parsed.
+async function callTranslationAPI(endpoint, headers, body, isClaudeShape) {
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body)
+  });
 
-  // Claude API format: {"type": "error", "error": {...}}
-  if (data?.type === 'error' && data?.error) {
-    const message = data.error.message || JSON.stringify(data.error);
-    return { isError: true, message, code: data.error.type || httpStatus };
-  }
-
-  // Ollama format: {"error": "..."}
-  if (typeof data?.error === 'string') {
-    return { isError: true, message: data.error, code: httpStatus };
-  }
-
-  // No error found
-  return { isError: false };
-}
-
-// Format error message for user display
-function formatErrorMessage(message, code) {
-  // Common error code mappings
-  const errorCodeMessages = {
-    401: '认证失败：请检查 API Key 是否正确',
-    402: '额度不足：请检查账户余额或升级套餐',
-    403: '访问被拒绝：API Key 可能没有权限',
-    404: '模型不存在：请检查模型名称是否正确',
-    429: '请求过于频繁：请稍后重试',
-    500: '服务器错误：API 服务暂时不可用',
-    502: '网关错误：API 服务暂时不可用',
-    503: '服务不可用：API 服务暂时不可用'
-  };
-
-  // If code is a known HTTP status, prepend a helpful message
-  const numericCode = parseInt(code);
-  if (errorCodeMessages[numericCode]) {
-    return `${errorCodeMessages[numericCode]}\n${message}`;
-  }
-
-  return message;
+  const data = await response.json().catch(() => ({}));
+  const result = readAPIResponse(data, response.status, response.ok, isClaudeShape);
+  if (result.error) throw new Error(result.error);
+  return result.text;
 }
 
 // Call Claude API with Anthropic-specific format
 async function callClaudeAPI(endpoint, apiKey, model, systemPrompt, userContent, maxTokens = 4096) {
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': apiKey,
-      'anthropic-version': '2023-06-01'
-    },
-    body: JSON.stringify({
-      model: model,
-      // Latest Claude models may spend budget on thinking; floor it so short
-      // translations aren't truncated to empty (see tokenBudgetFor).
-      max_tokens: tokenBudgetFor(model, maxTokens),
-      system: systemPrompt,
-      messages: [
-        { role: 'user', content: userContent }
-      ]
-    })
-  });
-
-  const data = await response.json().catch(() => ({}));
-
-  // Check HTTP status first
-  if (!response.ok) {
-    const errorInfo = parseAPIError(data, response.status);
-    const message = errorInfo.isError
-      ? formatErrorMessage(errorInfo.message, errorInfo.code)
-      : `API 错误: ${response.status}`;
-    throw new Error(message);
-  }
-
-  // Also check for error in response body (some APIs return 200 with error)
-  const errorInfo = parseAPIError(data, response.status);
-  if (errorInfo.isError) {
-    throw new Error(formatErrorMessage(errorInfo.message, errorInfo.code));
-  }
-
-  // Claude response format: { content: [{ type: "text", text: "..." }] }
-  return data.content?.[0]?.text?.trim() || '';
-}
-
-// Normalize a model name for capability detection (strip provider prefixes like "openai/").
-function normalizeModelName(model) {
-  const name = String(model || '').toLowerCase().trim();
-  return name.includes('/') ? name.split('/').pop() : name;
-}
-
-// GPT-5.x and o-series reasoning models renamed `max_tokens` to `max_completion_tokens`
-// and only accept the default temperature (an explicit temperature returns HTTP 400).
-function isOpenAIReasoningModel(model) {
-  const name = normalizeModelName(model);
-  return /^gpt-5/.test(name) || /^o[1-9]/.test(name);
-}
-
-// Compare the version embedded in a gpt-* model name ("gpt-5.6-luna" -> 5.6).
-// Major and minor are compared separately so a future "gpt-5.10" sorts above
-// "gpt-5.6" instead of being read as the decimal 5.1.
-function gptVersionAtLeast(model, major, minor) {
-  const match = normalizeModelName(model).match(/^gpt-(\d+)(?:\.(\d+))?/);
-  if (!match) return false;
-  const gotMajor = parseInt(match[1], 10);
-  const gotMinor = match[2] ? parseInt(match[2], 10) : 0;
-  return gotMajor > major || (gotMajor === major && gotMinor >= minor);
-}
-
-// Lowest `reasoning_effort` the model accepts, or null when it has no such
-// control. Translation never needs chain-of-thought, so we always ask for the
-// floor — but the name of that floor changed across generations:
-//   gpt-5 … gpt-5.5  -> 'minimal'
-//   gpt-5.6+         -> 'minimal' was dropped; the floor is now 'none'
-// Sending 'minimal' to gpt-5.6-{sol,terra,luna} fails with HTTP 400
-// ("Unsupported value: 'reasoning_effort' does not support 'minimal'").
-// The o-series never accepted either value, so it gets nothing.
-function minimalReasoningEffort(model) {
-  if (!gptVersionAtLeast(model, 5, 0)) return null;
-  return gptVersionAtLeast(model, 5, 6) ? 'none' : 'minimal';
-}
-
-// Gemini 3+ is tuned around its default temperature (1.0). Google's guidance is
-// to leave temperature unset: lowering it — standard practice on older models —
-// can push these models into loops or degrade quality on harder input.
-function isGemini3OrNewer(model) {
-  const match = normalizeModelName(model).match(/^gemini-(\d+)/);
-  return match ? parseInt(match[1], 10) >= 3 : false;
-}
-
-// Newer Claude models reject `temperature`/`top_p` ("deprecated for this model"),
-// including when reached through an OpenAI-compatible gateway. The native Claude
-// path already omits temperature, so mirror that here for any Claude model.
-function isClaudeModelName(model) {
-  const name = normalizeModelName(model);
-  return /claude|opus|sonnet|haiku|fable/.test(name);
-}
-
-// Reasoning (GPT-5/o-series), modern thinking (Claude) and Gemini 3+ models
-// spend part of the output budget on hidden reasoning/thinking tokens. A short
-// call such as a single-word lookup (budget 800) can be consumed entirely by
-// that hidden spend, returning empty text with finish_reason "length". Give
-// these models a floor so the visible translation always has room. The token
-// limit is only a cap, so raising it never lengthens a normal translation.
-// Gemini 3 belongs here because its thinking cannot be switched off.
-const REASONING_TOKEN_FLOOR = 2000;
-
-function tokenBudgetFor(model, maxTokens) {
-  if (isOpenAIReasoningModel(model) || isClaudeModelName(model) || isGemini3OrNewer(model)) {
-    return Math.max(maxTokens, REASONING_TOKEN_FLOOR);
-  }
-  return maxTokens;
-}
-
-// Build an OpenAI-compatible request body with model-aware parameters.
-function buildOpenAIRequestBody(model, messages, maxTokens, temperature) {
-  const body = { model, messages };
-  const tokenLimit = tokenBudgetFor(model, maxTokens);
-
-  if (isOpenAIReasoningModel(model)) {
-    // GPT-5.x / o-series: new token-limit field, default temperature only.
-    body.max_completion_tokens = tokenLimit;
-    // Skip heavy chain-of-thought for translation, using whichever spelling of
-    // the floor this generation accepts.
-    const effort = minimalReasoningEffort(model);
-    if (effort) {
-      body.reasoning_effort = effort;
-    }
-  } else {
-    body.max_tokens = tokenLimit;
-    if (typeof temperature === 'number' && !isClaudeModelName(model) && !isGemini3OrNewer(model)) {
-      body.temperature = temperature;
-    }
-  }
-
-  return body;
+  return callTranslationAPI(
+    endpoint,
+    claudeHeaders(apiKey),
+    buildClaudeRequestBody(model, userContent, maxTokens, systemPrompt),
+    true
+  );
 }
 
 // Call OpenAI-compatible API
-async function callOpenAIAPI(endpoint, apiKey, model, systemPrompt, userContent, maxTokens = 4096, temperature = 0.3) {
+async function callOpenAIAPI(endpoint, apiKey, model, systemPrompt, userContent, maxTokens = 4096, temperature = globalThis.APICompat.DEFAULT_TEMPERATURE) {
   const messages = [
     { role: 'system', content: systemPrompt },
     { role: 'user', content: userContent }
   ];
-  const response = await fetch(endpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${apiKey}`
-    },
-    body: JSON.stringify(buildOpenAIRequestBody(model, messages, maxTokens, temperature))
-  });
-
-  const data = await response.json().catch(() => ({}));
-
-  // Check HTTP status first
-  if (!response.ok) {
-    const errorInfo = parseAPIError(data, response.status);
-    const message = errorInfo.isError
-      ? formatErrorMessage(errorInfo.message, errorInfo.code)
-      : `API 错误: ${response.status}`;
-    throw new Error(message);
-  }
-
-  // Also check for error in response body (some APIs like OpenRouter return 200 with error)
-  const errorInfo = parseAPIError(data, response.status);
-  if (errorInfo.isError) {
-    throw new Error(formatErrorMessage(errorInfo.message, errorInfo.code));
-  }
-
-  // OpenAI response format: { choices: [{ message: { content: "..." } }] }
-  return data.choices?.[0]?.message?.content?.trim() || '';
+  return callTranslationAPI(
+    endpoint,
+    openAIHeaders(apiKey),
+    buildOpenAIRequestBody(model, messages, maxTokens, temperature),
+    false
+  );
 }
 
 // Message listener

--- a/background/background.js
+++ b/background/background.js
@@ -440,12 +440,36 @@ function isOpenAIReasoningModel(model) {
   return /^gpt-5/.test(name) || /^o[1-9]/.test(name);
 }
 
-// The GPT-5 family (gpt-5, gpt-5-mini, gpt-5.4-mini, gpt-5.5, ...) accepts the
-// `reasoning_effort` control; 'minimal' skips heavy chain-of-thought, keeping
-// translation fast and cheap. The o-series (o1..) does NOT support 'minimal',
-// so it is only sent for gpt-5*.
-function isGpt5Family(model) {
-  return /^gpt-5/.test(normalizeModelName(model));
+// Compare the version embedded in a gpt-* model name ("gpt-5.6-luna" -> 5.6).
+// Major and minor are compared separately so a future "gpt-5.10" sorts above
+// "gpt-5.6" instead of being read as the decimal 5.1.
+function gptVersionAtLeast(model, major, minor) {
+  const match = normalizeModelName(model).match(/^gpt-(\d+)(?:\.(\d+))?/);
+  if (!match) return false;
+  const gotMajor = parseInt(match[1], 10);
+  const gotMinor = match[2] ? parseInt(match[2], 10) : 0;
+  return gotMajor > major || (gotMajor === major && gotMinor >= minor);
+}
+
+// Lowest `reasoning_effort` the model accepts, or null when it has no such
+// control. Translation never needs chain-of-thought, so we always ask for the
+// floor — but the name of that floor changed across generations:
+//   gpt-5 … gpt-5.5  -> 'minimal'
+//   gpt-5.6+         -> 'minimal' was dropped; the floor is now 'none'
+// Sending 'minimal' to gpt-5.6-{sol,terra,luna} fails with HTTP 400
+// ("Unsupported value: 'reasoning_effort' does not support 'minimal'").
+// The o-series never accepted either value, so it gets nothing.
+function minimalReasoningEffort(model) {
+  if (!gptVersionAtLeast(model, 5, 0)) return null;
+  return gptVersionAtLeast(model, 5, 6) ? 'none' : 'minimal';
+}
+
+// Gemini 3+ is tuned around its default temperature (1.0). Google's guidance is
+// to leave temperature unset: lowering it — standard practice on older models —
+// can push these models into loops or degrade quality on harder input.
+function isGemini3OrNewer(model) {
+  const match = normalizeModelName(model).match(/^gemini-(\d+)/);
+  return match ? parseInt(match[1], 10) >= 3 : false;
 }
 
 // Newer Claude models reject `temperature`/`top_p` ("deprecated for this model"),
@@ -456,16 +480,17 @@ function isClaudeModelName(model) {
   return /claude|opus|sonnet|haiku|fable/.test(name);
 }
 
-// Reasoning (GPT-5/o-series) and modern thinking (Claude) models spend part of
-// the output budget on hidden reasoning/thinking tokens. A short call such as a
-// single-word lookup (budget 800) can be consumed entirely by that hidden spend,
-// returning empty text with finish_reason "length". Give these models a floor so
-// the visible translation always has room. The token limit is only a cap, so
-// raising it never lengthens a normal translation.
+// Reasoning (GPT-5/o-series), modern thinking (Claude) and Gemini 3+ models
+// spend part of the output budget on hidden reasoning/thinking tokens. A short
+// call such as a single-word lookup (budget 800) can be consumed entirely by
+// that hidden spend, returning empty text with finish_reason "length". Give
+// these models a floor so the visible translation always has room. The token
+// limit is only a cap, so raising it never lengthens a normal translation.
+// Gemini 3 belongs here because its thinking cannot be switched off.
 const REASONING_TOKEN_FLOOR = 2000;
 
 function tokenBudgetFor(model, maxTokens) {
-  if (isOpenAIReasoningModel(model) || isClaudeModelName(model)) {
+  if (isOpenAIReasoningModel(model) || isClaudeModelName(model) || isGemini3OrNewer(model)) {
     return Math.max(maxTokens, REASONING_TOKEN_FLOOR);
   }
   return maxTokens;
@@ -479,13 +504,15 @@ function buildOpenAIRequestBody(model, messages, maxTokens, temperature) {
   if (isOpenAIReasoningModel(model)) {
     // GPT-5.x / o-series: new token-limit field, default temperature only.
     body.max_completion_tokens = tokenLimit;
-    // Skip heavy chain-of-thought for translation (GPT-5 family only).
-    if (isGpt5Family(model)) {
-      body.reasoning_effort = 'minimal';
+    // Skip heavy chain-of-thought for translation, using whichever spelling of
+    // the floor this generation accepts.
+    const effort = minimalReasoningEffort(model);
+    if (effort) {
+      body.reasoning_effort = effort;
     }
   } else {
     body.max_tokens = tokenLimit;
-    if (typeof temperature === 'number' && !isClaudeModelName(model)) {
+    if (typeof temperature === 'number' && !isClaudeModelName(model) && !isGemini3OrNewer(model)) {
       body.temperature = temperature;
     }
   }

--- a/options/options.html
+++ b/options/options.html
@@ -501,6 +501,7 @@
     </footer>
   </div>
 
+  <script src="../shared/api-compat.js"></script>
   <script src="../i18n/messages.js"></script>
   <!-- 内置引擎的语言码映射、可用性查询和首次下载都在这里；设置页复用同一份实现，
        避免和 content script 各写一套语言码映射后慢慢走偏。 -->

--- a/options/options.js
+++ b/options/options.js
@@ -340,12 +340,35 @@ function onProviderChange() {
   updateModelDropdown(providerKey);
 }
 
+// ---------------------------------------------------------------------------
+// Model: one setting, two controls
+//
+// The dropdown and the free-text box both write `modelName`, and the text box
+// wins (getEffectiveModelName). So whenever one of them takes over, the other
+// has to visibly let go — otherwise the page asserts two different models at
+// once and the user has no way to tell which one is really being sent.
+//
+// Only the dropdown side of that was implemented. Picking "claude-opus-5" and
+// then typing a model of your own stored the typed name correctly, but the
+// dropdown went on displaying claude-opus-5 — so the typed name looked ignored.
+// ---------------------------------------------------------------------------
+
 // Handle model select change
 function onModelSelectChange() {
   const selectedModel = elements.modelSelect.value;
   if (selectedModel) {
     // Clear custom input when selecting from dropdown
     elements.modelName.value = '';
+  }
+}
+
+// The mirror image: typing overrides the list, so the list drops back to its
+// placeholder. Emptying the box hands control back and leaves the dropdown to
+// be chosen again — deliberately not restoring the old pick, which would
+// resurrect a model the user had already replaced.
+function onCustomModelInput() {
+  if (elements.modelName.value.trim() && elements.modelSelect.value) {
+    elements.modelSelect.value = '';
   }
 }
 
@@ -709,8 +732,6 @@ async function persistSettings({ reapplyI18n = false } = {}) {
     return;
   }
 
-  // Claimed before the write, compared after it. See the yield below.
-  const seq = statusSeq;
   try {
     await chrome.storage.sync.set(settings);
     lastGoodSettings = settings;
@@ -723,18 +744,12 @@ async function persistSettings({ reapplyI18n = false } = {}) {
       applyPlatformHotkeyLabels();
     }
 
-    if (statusSeq === seq) {
-      // The save confirmation yields. It is routine reassurance, while every
-      // other message on this strip answers a deliberate action — so if anyone
-      // spoke while the write was in flight, leave their message alone.
-      //
-      // The case that forced this: clicking Test Connection blurs the field
-      // being edited, so the flush lands in the middle of the probe. Whichever
-      // finished last used to win, meaning a connection result could be
-      // replaced by "settings saved" — the user asked a question and got an
-      // unrelated answer. The write itself is unaffected either way.
-      showStatus(t('settingsSaved'), 'success');
-    }
+    // Deliberately silent. Autosave fires on every keystroke and every toggle,
+    // so confirming each one turned the status strip into a flashing banner
+    // that said nothing the user did not already know — and trained them to
+    // ignore the strip, which is also where hotkey conflicts and connection
+    // failures appear. Success is the expected outcome; only deviations from it
+    // are worth interrupting for.
   } catch (error) {
     console.error('Failed to save settings:', error);
     showStatus(t('connectionFailed'), 'error');
@@ -880,22 +895,20 @@ function toggleApiKeyVisibility() {
 // ---------------------------------------------------------------------------
 // Status area
 //
-// One strip serves autosave, connection tests, sign-in and presets, so writes
-// to it have to be ordered rather than last-one-wins. `statusSeq` counts them,
-// which lets a slow async writer notice that someone else has since spoken and
-// hold its tongue — see persistSettings.
+// The strip only ever answers a deliberate action now — a connection test, a
+// sign-in, a preset, a rejected hotkey. Autosave used to write here too, on
+// every keystroke, which is what made ordering between writers a problem; with
+// that gone, last-one-wins is the whole rule.
 // ---------------------------------------------------------------------------
 let statusHideTimer = null;
-let statusSeq = 0;
 
 // Show status message
 function showStatus(message, type) {
   // Cancelling the previous hide is the point: these timers used to be left
-  // running, so a save confirmation shown at t=0 would blank whatever occupied
-  // the strip at t=3s — typically a connection error that arrived in between.
+  // running, so a message shown at t=0 would blank whatever occupied the strip
+  // at t=3s — typically an error that arrived in between.
   clearTimeout(statusHideTimer);
   statusHideTimer = null;
-  statusSeq += 1;
 
   elements.statusMessage.textContent = message;
   elements.statusMessage.className = `status-message ${type}`;
@@ -1076,6 +1089,11 @@ function setupEventListeners() {
     onModelSelectChange();
     persistSettings();
   });
+
+  // The write this keystroke also triggers is debounced, so the dropdown is
+  // already released by the time collectSettings reads the pair — regardless of
+  // which listener the browser happens to call first.
+  elements.modelName.addEventListener('input', onCustomModelInput);
 
   elements.enableSelection.addEventListener('change', syncInlineSettingState);
   elements.enableHoverTranslation.addEventListener('change', syncInlineSettingState);

--- a/options/options.js
+++ b/options/options.js
@@ -17,97 +17,19 @@ function getPlatformType() {
 const DEFAULT_SELECTION_HOTKEY = isMacPlatform() ? 'Meta' : 'Control';
 
 // Provider configurations
-const PROVIDERS = {
-  openai: {
-    name: 'OpenAI',
-    endpoint: 'https://api.openai.com/v1/chat/completions',
-    // gpt-5.6 ships as three tiers (sol > terra > luna); the bare "gpt-5.6"
-    // alias routes to sol. Luna is the high-volume tier, so it leads the list.
-    models: ['gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-5', 'gpt-5-mini', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4o', 'gpt-4o-mini', 'o3', 'o3-mini', 'o4-mini'],
-    defaultModel: 'gpt-4.1-mini'
-  },
-  anthropic: {
-    name: 'Anthropic Claude',
-    endpoint: 'https://api.anthropic.com/v1/messages',
-    // Native Anthropic API accepts version aliases (no date suffix); aliases
-    // always resolve to the latest snapshot and avoid stale/incorrect dates.
-    // claude-opus-4-1 is dropped here: it retires 2026-08-05.
-    models: ['claude-opus-5', 'claude-sonnet-5', 'claude-fable-5', 'claude-haiku-4-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-5', 'claude-sonnet-4-5'],
-    defaultModel: 'claude-sonnet-5'
-  },
-  gemini: {
-    name: 'Google Gemini',
-    endpoint: 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
-    // Only stable text models: gemini-3-pro/gemini-3-flash never reached stable
-    // (Pro is preview-only) and the 2.0 line was shut down on 2026-06-01.
-    models: ['gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3.5-flash-lite', 'gemini-3.1-flash-lite', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite'],
-    defaultModel: 'gemini-3.6-flash'
-  },
-  deepseek: {
-    name: 'DeepSeek',
-    endpoint: 'https://api.deepseek.com/v1/chat/completions',
-    models: ['deepseek-chat', 'deepseek-reasoner'],
-    defaultModel: 'deepseek-chat'
-  },
-  openrouter: {
-    name: 'OpenRouter',
-    endpoint: 'https://openrouter.ai/api/v1/chat/completions',
-    models: [
-      // Anthropic Claude
-      'anthropic/claude-opus-5',
-      'anthropic/claude-sonnet-5',
-      'anthropic/claude-opus-4.8',
-      'anthropic/claude-opus-4.5',
-      'anthropic/claude-sonnet-4.5',
-      'anthropic/claude-haiku-4.5',
-      'anthropic/claude-sonnet-4',
-      'anthropic/claude-opus-4',
-      // OpenAI
-      'openai/gpt-5.6-luna',
-      'openai/gpt-5.6-terra',
-      'openai/gpt-5.6-sol',
-      'openai/gpt-5.5',
-      'openai/gpt-5',
-      'openai/gpt-5-mini',
-      'openai/gpt-4.1',
-      'openai/gpt-4.1-mini',
-      'openai/gpt-4.1-nano',
-      'openai/gpt-4o',
-      'openai/gpt-4o-mini',
-      'openai/o3',
-      'openai/o3-mini',
-      'openai/o4-mini',
-      // Google Gemini
-      'google/gemini-3.6-flash',
-      'google/gemini-3.5-flash',
-      'google/gemini-3.5-flash-lite',
-      'google/gemini-2.5-pro',
-      'google/gemini-2.5-flash',
-      // DeepSeek
-      'deepseek/deepseek-chat',
-      'deepseek/deepseek-reasoner'
-    ],
-    defaultModel: 'anthropic/claude-sonnet-5'
-  },
-  ollama: {
-    name: 'Ollama (Local)',
-    endpoint: 'http://localhost:11434/v1/chat/completions',
-    models: ['llama3.3', 'qwen2.5', 'deepseek-r1', 'gemma2'],
-    defaultModel: 'llama3.3'
-  },
-  lmstudio: {
-    name: 'LM Studio (Local)',
-    endpoint: 'http://localhost:1234/v1/chat/completions',
-    models: [],
-    defaultModel: ''
-  },
-  custom: {
-    name: 'Custom',
-    endpoint: '',
-    models: [],
-    defaultModel: ''
-  }
-};
+// Provider catalog and every model-capability rule live in shared/api-compat.js
+// (loaded by options.html before this file). Adding a model generation is a
+// one-file change there.
+const {
+  PROVIDERS,
+  DEFAULT_TEMPERATURE,
+  isClaudeAPI,
+  openAIHeaders,
+  claudeHeaders,
+  buildOpenAIRequestBody,
+  buildClaudeRequestBody,
+  readAPIResponse
+} = globalThis.APICompat;
 
 // Current UI language
 let currentUILang = 'en';
@@ -847,36 +769,9 @@ async function notifyContentScripts(settings) {
   }
 }
 
-// Detect if the API endpoint is Anthropic Claude API
-function isClaudeAPI(endpoint) {
-  if (!endpoint) return false;
-  return endpoint.includes('anthropic.com') || endpoint.includes('/v1/messages');
-}
-
-// GPT-5.x and o-series reasoning models use `max_completion_tokens` instead of
-// `max_tokens`; sending `max_tokens` to them returns HTTP 400.
-function isOpenAIReasoningModel(model) {
-  const name = String(model || '').toLowerCase().trim();
-  const shortName = name.includes('/') ? name.split('/').pop() : name;
-  return /^gpt-5/.test(shortName) || /^o[1-9]/.test(shortName);
-}
-
-// Lowest `reasoning_effort` the model accepts, or null when it has no such
-// control, so the probe returns text quickly instead of burning its budget on
-// hidden reasoning. The name of that floor changed across generations:
-// gpt-5…gpt-5.5 use 'minimal'; gpt-5.6+ dropped it in favour of 'none' and
-// reject 'minimal' with HTTP 400. The o-series accepts neither.
-// Keep in sync with background/background.js.
-function minimalReasoningEffort(model) {
-  const name = String(model || '').toLowerCase().trim();
-  const shortName = name.includes('/') ? name.split('/').pop() : name;
-  const match = shortName.match(/^gpt-(\d+)(?:\.(\d+))?/);
-  if (!match) return null;
-  const major = parseInt(match[1], 10);
-  const minor = match[2] ? parseInt(match[2], 10) : 0;
-  if (major < 5) return null;
-  return major > 5 || minor >= 6 ? 'none' : 'minimal';
-}
+// Endpoint/model shape helpers live in shared/api-compat.js — the same
+// module the service worker uses, so the connection test below proves the
+// exact request translation will make.
 
 // Test API connection
 async function testConnection() {
@@ -912,62 +807,34 @@ async function testConnection() {
 
   showStatus(t('translating'), 'warning');
 
+  // The probe is built by the same helpers the service worker translates with,
+  // so "connection successful" means the real request shape was accepted — not
+  // merely that the endpoint and key exist.
+  const claudeShape = isClaudeAPI(apiEndpoint);
+  // 20 tokens is enough for "Hi", but reasoning/thinking models bill hidden
+  // tokens against the same budget; the shared builder raises the floor for
+  // those, so ask for a small budget and let it decide.
+  const PROBE_TOKENS = 20;
+  const headers = claudeShape ? claudeHeaders(apiKey) : openAIHeaders(apiKey);
+  const body = claudeShape
+    ? buildClaudeRequestBody(modelName, 'Hi', PROBE_TOKENS)
+    : buildOpenAIRequestBody(modelName, [{ role: 'user', content: 'Hi' }], PROBE_TOKENS, DEFAULT_TEMPERATURE);
+
   try {
-    let response;
+    const response = await fetch(apiEndpoint, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body)
+    });
 
-    if (isClaudeAPI(apiEndpoint)) {
-      // Use Claude API format
-      response = await fetch(apiEndpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': apiKey,
-          'anthropic-version': '2023-06-01'
-        },
-        body: JSON.stringify({
-          model: modelName || 'claude-sonnet-5',
-          // Room for a reply even when the model spends budget on thinking.
-          max_tokens: 256,
-          messages: [
-            { role: 'user', content: 'Hi' }
-          ]
-        })
-      });
+    // Vendors disagree on error shape and some report failures with HTTP 200,
+    // so always read the body rather than trusting response.ok alone.
+    const data = await response.json().catch(() => ({}));
+    const result = readAPIResponse(data, response.status, response.ok, claudeShape);
+    if (result.error) {
+      showStatus(`${t('connectionFailed')}: ${result.error}`, 'error');
     } else {
-      // Use OpenAI-compatible API format
-      const testModel = modelName || 'gpt-4.1-mini';
-      const testBody = {
-        model: testModel,
-        messages: [
-          { role: 'user', content: 'Hi' }
-        ]
-      };
-      // GPT-5.x / o-series reasoning models require max_completion_tokens and
-      // spend part of it on hidden reasoning — give the probe room to reply.
-      if (isOpenAIReasoningModel(testModel)) {
-        testBody.max_completion_tokens = 256;
-        const effort = minimalReasoningEffort(testModel);
-        if (effort) {
-          testBody.reasoning_effort = effort;
-        }
-      } else {
-        testBody.max_tokens = 20;
-      }
-      response = await fetch(apiEndpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${apiKey}`
-        },
-        body: JSON.stringify(testBody)
-      });
-    }
-
-    if (response.ok) {
       showStatus(t('connectionSuccess'), 'success');
-    } else {
-      const error = await response.json().catch(() => ({}));
-      showStatus(`${t('connectionFailed')}: ${error.error?.message || response.status}`, 'error');
     }
   } catch (error) {
     showStatus(`${t('connectionFailed')}: ${error.message}`, 'error');

--- a/options/options.js
+++ b/options/options.js
@@ -21,7 +21,9 @@ const PROVIDERS = {
   openai: {
     name: 'OpenAI',
     endpoint: 'https://api.openai.com/v1/chat/completions',
-    models: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-5', 'gpt-5-mini', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4o', 'gpt-4o-mini', 'o3', 'o3-mini', 'o4-mini'],
+    // gpt-5.6 ships as three tiers (sol > terra > luna); the bare "gpt-5.6"
+    // alias routes to sol. Luna is the high-volume tier, so it leads the list.
+    models: ['gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-5', 'gpt-5-mini', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4o', 'gpt-4o-mini', 'o3', 'o3-mini', 'o4-mini'],
     defaultModel: 'gpt-4.1-mini'
   },
   anthropic: {
@@ -29,14 +31,17 @@ const PROVIDERS = {
     endpoint: 'https://api.anthropic.com/v1/messages',
     // Native Anthropic API accepts version aliases (no date suffix); aliases
     // always resolve to the latest snapshot and avoid stale/incorrect dates.
-    models: ['claude-opus-4-8', 'claude-sonnet-5', 'claude-haiku-4-5', 'claude-fable-5', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-5', 'claude-sonnet-4-5', 'claude-opus-4-1'],
+    // claude-opus-4-1 is dropped here: it retires 2026-08-05.
+    models: ['claude-opus-5', 'claude-sonnet-5', 'claude-fable-5', 'claude-haiku-4-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-5', 'claude-sonnet-4-5'],
     defaultModel: 'claude-sonnet-5'
   },
   gemini: {
     name: 'Google Gemini',
     endpoint: 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
-    models: ['gemini-3.5-flash', 'gemini-3-pro', 'gemini-3-flash', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.0-flash'],
-    defaultModel: 'gemini-3-flash'
+    // Only stable text models: gemini-3-pro/gemini-3-flash never reached stable
+    // (Pro is preview-only) and the 2.0 line was shut down on 2026-06-01.
+    models: ['gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3.5-flash-lite', 'gemini-3.1-flash-lite', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite'],
+    defaultModel: 'gemini-3.6-flash'
   },
   deepseek: {
     name: 'DeepSeek',
@@ -49,15 +54,18 @@ const PROVIDERS = {
     endpoint: 'https://openrouter.ai/api/v1/chat/completions',
     models: [
       // Anthropic Claude
-      'anthropic/claude-opus-4.8',
+      'anthropic/claude-opus-5',
       'anthropic/claude-sonnet-5',
+      'anthropic/claude-opus-4.8',
       'anthropic/claude-opus-4.5',
       'anthropic/claude-sonnet-4.5',
       'anthropic/claude-haiku-4.5',
-      'anthropic/claude-opus-4.1',
       'anthropic/claude-sonnet-4',
       'anthropic/claude-opus-4',
       // OpenAI
+      'openai/gpt-5.6-luna',
+      'openai/gpt-5.6-terra',
+      'openai/gpt-5.6-sol',
       'openai/gpt-5.5',
       'openai/gpt-5',
       'openai/gpt-5-mini',
@@ -70,9 +78,9 @@ const PROVIDERS = {
       'openai/o3-mini',
       'openai/o4-mini',
       // Google Gemini
+      'google/gemini-3.6-flash',
       'google/gemini-3.5-flash',
-      'google/gemini-3-flash',
-      'google/gemini-3-pro',
+      'google/gemini-3.5-flash-lite',
       'google/gemini-2.5-pro',
       'google/gemini-2.5-flash',
       // DeepSeek
@@ -853,12 +861,21 @@ function isOpenAIReasoningModel(model) {
   return /^gpt-5/.test(shortName) || /^o[1-9]/.test(shortName);
 }
 
-// GPT-5 family accepts `reasoning_effort`; 'minimal' skips heavy reasoning so a
-// probe returns text quickly. The o-series does not support 'minimal'.
-function isGpt5Family(model) {
+// Lowest `reasoning_effort` the model accepts, or null when it has no such
+// control, so the probe returns text quickly instead of burning its budget on
+// hidden reasoning. The name of that floor changed across generations:
+// gpt-5…gpt-5.5 use 'minimal'; gpt-5.6+ dropped it in favour of 'none' and
+// reject 'minimal' with HTTP 400. The o-series accepts neither.
+// Keep in sync with background/background.js.
+function minimalReasoningEffort(model) {
   const name = String(model || '').toLowerCase().trim();
   const shortName = name.includes('/') ? name.split('/').pop() : name;
-  return /^gpt-5/.test(shortName);
+  const match = shortName.match(/^gpt-(\d+)(?:\.(\d+))?/);
+  if (!match) return null;
+  const major = parseInt(match[1], 10);
+  const minor = match[2] ? parseInt(match[2], 10) : 0;
+  if (major < 5) return null;
+  return major > 5 || minor >= 6 ? 'none' : 'minimal';
 }
 
 // Test API connection
@@ -929,8 +946,9 @@ async function testConnection() {
       // spend part of it on hidden reasoning — give the probe room to reply.
       if (isOpenAIReasoningModel(testModel)) {
         testBody.max_completion_tokens = 256;
-        if (isGpt5Family(testModel)) {
-          testBody.reasoning_effort = 'minimal';
+        const effort = minimalReasoningEffort(testModel);
+        if (effort) {
+          testBody.reasoning_effort = effort;
         }
       } else {
         testBody.max_tokens = 20;

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "scripts": {
     "icons": "node scripts/generate-icons.js",
     "build": "echo 'No build required - load directly in Chrome'",
-    "zip": "V=$(node -p \"require('./manifest.json').version\") && rm -f ai-translator-$V.zip && zip -r ai-translator-$V.zip manifest.json _locales/ background/ content/ i18n/ options/ popup/ pdf/ icons/icon16.png icons/icon32.png icons/icon48.png icons/icon128.png icons/icon16-light.png icons/icon32-light.png icons/icon48-light.png icons/icon128-light.png -x '*.DS_Store'",
-    "test": "npx playwright test",
+    "zip": "V=$(node -p \"require('./manifest.json').version\") && rm -f ai-translator-$V.zip && zip -r ai-translator-$V.zip manifest.json _locales/ background/ content/ i18n/ options/ popup/ pdf/ shared/ icons/icon16.png icons/icon32.png icons/icon48.png icons/icon128.png icons/icon16-light.png icons/icon32-light.png icons/icon48-light.png icons/icon128-light.png -x '*.DS_Store'",
+    "test": "npm run test:unit && npx playwright test",
+    "test:unit": "node --test 'test/unit/**/*.test.mjs'",
+    "test:e2e": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:ui": "npx playwright test --ui",
     "test:debug": "npx playwright test --debug",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "npm run test:unit && npx playwright test",
     "test:unit": "node --test 'test/unit/**/*.test.mjs'",
     "test:e2e": "npx playwright test",
-    "test:headed": "npx playwright test --headed",
+    "test:headed": "HEADED=1 npx playwright test",
     "test:ui": "npx playwright test --ui",
     "test:debug": "npx playwright test --debug",
     "test:float-ball": "npx playwright test float-ball.spec.js",

--- a/shared/api-compat.js
+++ b/shared/api-compat.js
@@ -1,0 +1,359 @@
+// Provider API compatibility: the single place that knows how each vendor's
+// endpoint is shaped and which parameters a given model accepts.
+//
+// MAINTENANCE CONTRACT
+// When a provider ships a new model generation, this file should be the only
+// one that needs editing. It is loaded by both the service worker (which does
+// the real translating) and the options page (whose "test connection" button
+// must exercise the exact same request shape — otherwise the probe can pass
+// while translation fails, which is how the gpt-5.6 breakage reached users).
+//
+// Model lineups last verified 2026-08-04 against:
+//   OpenAI    https://developers.openai.com/api/docs/guides/latest-model
+//   Anthropic https://platform.claude.com/docs/en/about-claude/models/overview
+//   Google    https://ai.google.dev/gemini-api/docs/models
+//
+// Loaded as a classic script by the options page and as a side-effect import by
+// the module service worker, so it publishes onto the global object rather than
+// using `export`.
+(function (root) {
+  'use strict';
+
+  // --- Model capability detection ------------------------------------------
+
+  // Strip provider prefixes ("openai/gpt-5.6-luna" -> "gpt-5.6-luna") so
+  // gateway-routed names are detected the same as direct ones.
+  function normalizeModelName(model) {
+    const name = String(model || '').toLowerCase().trim();
+    return name.includes('/') ? name.split('/').pop() : name;
+  }
+
+  // Compare the version embedded in a model name ("gpt-5.6-luna" -> 5.6).
+  // Major and minor are compared separately so a future "gpt-5.10" sorts above
+  // "gpt-5.6" instead of being read as the decimal 5.1.
+  function versionAtLeast(model, family, major, minor) {
+    const match = normalizeModelName(model).match(new RegExp(`^${family}-(\\d+)(?:\\.(\\d+))?`));
+    if (!match) return false;
+    const gotMajor = parseInt(match[1], 10);
+    const gotMinor = match[2] ? parseInt(match[2], 10) : 0;
+    return gotMajor > major || (gotMajor === major && gotMinor >= (minor || 0));
+  }
+
+  // GPT-5.x and o-series reasoning models renamed `max_tokens` to
+  // `max_completion_tokens` and only accept the default temperature (an
+  // explicit temperature returns HTTP 400).
+  //
+  // The whole GPT-5 line reasons, so anything at gpt-5 or above is assumed to
+  // as well — an unreleased gpt-6 then lands on the modern parameter shape
+  // instead of the legacy one. That is the safer guess in both directions:
+  // `max_completion_tokens` is the current field name and works for newer
+  // non-reasoning models too, whereas `max_tokens` is rejected outright by
+  // reasoning models. Re-verify when a new major generation actually ships.
+  function isOpenAIReasoningModel(model) {
+    return versionAtLeast(model, 'gpt', 5) || /^o[1-9]/.test(normalizeModelName(model));
+  }
+
+  // Lowest `reasoning_effort` the model accepts, or null when it has no such
+  // control. Translation never needs chain-of-thought, so we always ask for the
+  // floor — but the name of that floor changed across generations:
+  //   gpt-5 … gpt-5.5  -> 'minimal'
+  //   gpt-5.6+         -> 'minimal' was dropped; the floor is now 'none'
+  // Sending 'minimal' to gpt-5.6-{sol,terra,luna} fails with HTTP 400
+  // ("Unsupported value: 'reasoning_effort' does not support 'minimal'").
+  // The o-series never accepted either value, so it gets nothing.
+  function minimalReasoningEffort(model) {
+    if (!versionAtLeast(model, 'gpt', 5)) return null;
+    return versionAtLeast(model, 'gpt', 5, 6) ? 'none' : 'minimal';
+  }
+
+  // Gemini 3+ is tuned around its default temperature (1.0). Google's guidance
+  // is to leave temperature unset: lowering it — standard practice on older
+  // models — can push these models into loops or degrade quality on harder
+  // input. Gemini 3 also cannot switch thinking off.
+  function isGemini3OrNewer(model) {
+    return versionAtLeast(model, 'gemini', 3);
+  }
+
+  // Newer Claude models reject `temperature`/`top_p` ("deprecated for this
+  // model"), including when reached through an OpenAI-compatible gateway. The
+  // native Claude path never sends temperature, so mirror that for any Claude
+  // model however it is reached.
+  function isClaudeModelName(model) {
+    return /claude|opus|sonnet|haiku|fable|mythos/.test(normalizeModelName(model));
+  }
+
+  // Reasoning (GPT-5/o-series), modern thinking (Claude) and Gemini 3+ models
+  // spend part of the output budget on hidden reasoning/thinking tokens. A
+  // short call such as a single-word lookup (budget 800) can be consumed
+  // entirely by that hidden spend, returning empty text with finish_reason
+  // "length". Give these models a floor so the visible translation always has
+  // room. The token limit is only a cap, so raising it never lengthens a
+  // normal translation.
+  const REASONING_TOKEN_FLOOR = 2000;
+
+  function spendsHiddenTokens(model) {
+    return isOpenAIReasoningModel(model) || isClaudeModelName(model) || isGemini3OrNewer(model);
+  }
+
+  function tokenBudgetFor(model, maxTokens) {
+    return spendsHiddenTokens(model) ? Math.max(maxTokens, REASONING_TOKEN_FLOOR) : maxTokens;
+  }
+
+  // --- Endpoint detection ---------------------------------------------------
+
+  // Anthropic's native Messages API, as opposed to anything speaking the
+  // OpenAI Chat Completions shape (including Claude behind a gateway).
+  function isClaudeAPI(endpoint) {
+    if (!endpoint) return false;
+    return endpoint.includes('anthropic.com') || endpoint.includes('/v1/messages');
+  }
+
+  const CLAUDE_API_VERSION = '2023-06-01';
+
+  function openAIHeaders(apiKey) {
+    return {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    };
+  }
+
+  function claudeHeaders(apiKey) {
+    return {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': CLAUDE_API_VERSION
+    };
+  }
+
+  // --- Request bodies -------------------------------------------------------
+
+  // Translation wants stable, literal output, so it asks for a low temperature
+  // wherever the model still honours one. Shared so the connection test probes
+  // with the same value translation will use.
+  const DEFAULT_TEMPERATURE = 0.3;
+
+  // Build an OpenAI-compatible request body with model-aware parameters.
+  function buildOpenAIRequestBody(model, messages, maxTokens, temperature) {
+    const body = { model, messages };
+    const tokenLimit = tokenBudgetFor(model, maxTokens);
+
+    if (isOpenAIReasoningModel(model)) {
+      // GPT-5.x / o-series: new token-limit field, default temperature only.
+      body.max_completion_tokens = tokenLimit;
+      // Skip heavy chain-of-thought for translation, using whichever spelling
+      // of the floor this generation accepts.
+      const effort = minimalReasoningEffort(model);
+      if (effort) body.reasoning_effort = effort;
+    } else {
+      body.max_tokens = tokenLimit;
+      if (typeof temperature === 'number' && !isClaudeModelName(model) && !isGemini3OrNewer(model)) {
+        body.temperature = temperature;
+      }
+    }
+
+    return body;
+  }
+
+  // Build a native Anthropic Messages body. `systemPrompt` is optional: the
+  // connection probe sends none.
+  function buildClaudeRequestBody(model, userContent, maxTokens, systemPrompt) {
+    const body = {
+      model,
+      max_tokens: tokenBudgetFor(model, maxTokens),
+      messages: [{ role: 'user', content: userContent }]
+    };
+    if (systemPrompt) body.system = systemPrompt;
+    return body;
+  }
+
+  // --- Responses ------------------------------------------------------------
+
+  // Parse a vendor error out of a response body. Vendors disagree on the shape,
+  // and some return HTTP 200 with an error payload (OpenRouter does this).
+  function parseAPIError(data, httpStatus) {
+    if (data && data.error) {
+      const error = data.error;
+      // OpenAI/OpenRouter: {"error": {"message": "...", "code": ...}}
+      if (typeof error === 'object') {
+        return {
+          isError: true,
+          message: error.message || error.msg || JSON.stringify(error),
+          code: error.code || error.type || httpStatus
+        };
+      }
+      // Ollama and friends: {"error": "..."}
+      if (typeof error === 'string') {
+        return { isError: true, message: error, code: httpStatus };
+      }
+    }
+
+    // Anthropic: {"type": "error", "error": {...}}
+    if (data && data.type === 'error' && data.error) {
+      return {
+        isError: true,
+        message: data.error.message || JSON.stringify(data.error),
+        code: data.error.type || httpStatus
+      };
+    }
+
+    return { isError: false };
+  }
+
+  // Turn a parsed error into the string shown to the user. Errors that carry a
+  // familiar HTTP status get an explanation prepended, because vendor messages
+  // for these are often opaque.
+  const ERROR_CODE_MESSAGES = {
+    401: '认证失败：请检查 API Key 是否正确',
+    402: '额度不足：请检查账户余额或升级套餐',
+    403: '访问被拒绝：API Key 可能没有权限',
+    404: '模型不存在：请检查模型名称是否正确',
+    429: '请求过于频繁：请稍后重试',
+    500: '服务器错误：API 服务暂时不可用',
+    502: '网关错误：API 服务暂时不可用',
+    503: '服务不可用：API 服务暂时不可用'
+  };
+
+  function formatErrorMessage(message, code) {
+    const explanation = ERROR_CODE_MESSAGES[parseInt(code, 10)];
+    return explanation ? `${explanation}\n${message}` : message;
+  }
+
+  // Read one response body and return either its text or a thrown-ready error
+  // message. Returns { text } on success, { error } otherwise.
+  function readAPIResponse(data, httpStatus, ok, isClaudeShape) {
+    const errorInfo = parseAPIError(data, httpStatus);
+    if (errorInfo.isError) {
+      return { error: formatErrorMessage(errorInfo.message, errorInfo.code) };
+    }
+    if (!ok) {
+      return { error: `API 错误: ${httpStatus}` };
+    }
+    const text = isClaudeShape
+      // Claude: { content: [{ type: "text", text: "..." }] }
+      ? (data && data.content && data.content[0] && data.content[0].text)
+      // OpenAI: { choices: [{ message: { content: "..." } }] }
+      : (data && data.choices && data.choices[0] && data.choices[0].message
+        && data.choices[0].message.content);
+    return { text: (text || '').trim() };
+  }
+
+  // --- Provider catalog -----------------------------------------------------
+
+  const PROVIDERS = {
+    openai: {
+      name: 'OpenAI',
+      endpoint: 'https://api.openai.com/v1/chat/completions',
+      // gpt-5.6 ships as three tiers (sol > terra > luna); the bare "gpt-5.6"
+      // alias routes to sol. Luna is the high-volume tier, so it leads.
+      models: ['gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano', 'gpt-5', 'gpt-5-mini', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-4o', 'gpt-4o-mini', 'o3', 'o3-mini', 'o4-mini'],
+      defaultModel: 'gpt-4.1-mini'
+    },
+    anthropic: {
+      name: 'Anthropic Claude',
+      endpoint: 'https://api.anthropic.com/v1/messages',
+      // Native Anthropic API accepts version aliases (no date suffix); aliases
+      // avoid stale/incorrect dates. claude-opus-4-1 is omitted: it retires
+      // 2026-08-05.
+      models: ['claude-opus-5', 'claude-sonnet-5', 'claude-fable-5', 'claude-haiku-4-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-5', 'claude-sonnet-4-5'],
+      defaultModel: 'claude-sonnet-5'
+    },
+    gemini: {
+      name: 'Google Gemini',
+      endpoint: 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
+      // Stable text models only: gemini-3-pro/gemini-3-flash never reached
+      // stable (3.x Pro is preview-only) and the 2.0 line shut down
+      // 2026-06-01.
+      models: ['gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3.5-flash-lite', 'gemini-3.1-flash-lite', 'gemini-2.5-pro', 'gemini-2.5-flash', 'gemini-2.5-flash-lite'],
+      defaultModel: 'gemini-3.6-flash'
+    },
+    deepseek: {
+      name: 'DeepSeek',
+      endpoint: 'https://api.deepseek.com/v1/chat/completions',
+      models: ['deepseek-chat', 'deepseek-reasoner'],
+      defaultModel: 'deepseek-chat'
+    },
+    openrouter: {
+      name: 'OpenRouter',
+      endpoint: 'https://openrouter.ai/api/v1/chat/completions',
+      // OpenRouter spells versions with dots where the native APIs use dashes
+      // (anthropic/claude-opus-4.8 vs claude-opus-4-8).
+      models: [
+        // Anthropic Claude
+        'anthropic/claude-opus-5',
+        'anthropic/claude-sonnet-5',
+        'anthropic/claude-opus-4.8',
+        'anthropic/claude-opus-4.5',
+        'anthropic/claude-sonnet-4.5',
+        'anthropic/claude-haiku-4.5',
+        'anthropic/claude-sonnet-4',
+        'anthropic/claude-opus-4',
+        // OpenAI
+        'openai/gpt-5.6-luna',
+        'openai/gpt-5.6-terra',
+        'openai/gpt-5.6-sol',
+        'openai/gpt-5.5',
+        'openai/gpt-5',
+        'openai/gpt-5-mini',
+        'openai/gpt-4.1',
+        'openai/gpt-4.1-mini',
+        'openai/gpt-4.1-nano',
+        'openai/gpt-4o',
+        'openai/gpt-4o-mini',
+        'openai/o3',
+        'openai/o3-mini',
+        'openai/o4-mini',
+        // Google Gemini
+        'google/gemini-3.6-flash',
+        'google/gemini-3.5-flash',
+        'google/gemini-3.5-flash-lite',
+        'google/gemini-2.5-pro',
+        'google/gemini-2.5-flash',
+        // DeepSeek
+        'deepseek/deepseek-chat',
+        'deepseek/deepseek-reasoner'
+      ],
+      defaultModel: 'anthropic/claude-sonnet-5'
+    },
+    ollama: {
+      name: 'Ollama (Local)',
+      endpoint: 'http://localhost:11434/v1/chat/completions',
+      models: ['llama3.3', 'qwen2.5', 'deepseek-r1', 'gemma2'],
+      defaultModel: 'llama3.3'
+    },
+    lmstudio: {
+      name: 'LM Studio (Local)',
+      endpoint: 'http://localhost:1234/v1/chat/completions',
+      models: [],
+      defaultModel: ''
+    },
+    custom: {
+      name: 'Custom',
+      endpoint: '',
+      models: [],
+      defaultModel: ''
+    }
+  };
+
+  root.APICompat = {
+    normalizeModelName,
+    versionAtLeast,
+    isOpenAIReasoningModel,
+    minimalReasoningEffort,
+    isGemini3OrNewer,
+    isClaudeModelName,
+    spendsHiddenTokens,
+    REASONING_TOKEN_FLOOR,
+    tokenBudgetFor,
+    DEFAULT_TEMPERATURE,
+    isClaudeAPI,
+    CLAUDE_API_VERSION,
+    openAIHeaders,
+    claudeHeaders,
+    buildOpenAIRequestBody,
+    buildClaudeRequestBody,
+    parseAPIError,
+    formatErrorMessage,
+    readAPIResponse,
+    PROVIDERS
+  };
+})(globalThis);

--- a/test/e2e/feature-settings.spec.js
+++ b/test/e2e/feature-settings.spec.js
@@ -104,15 +104,12 @@ test('test connection sits in the API card and reports the missing field', async
 });
 
 /**
- * One status strip serves autosave, connection tests, sign-in and presets, and
- * autosave now writes to it constantly — so the two ways it could trample a
- * connection result both need pinning.
- *
- * First: a save confirmation auto-hides after three seconds, and that timer
- * used to be left running. Anything that appeared in the meantime got blanked
- * along with it.
+ * Autosave is silent: it fires on every keystroke and every toggle, so
+ * confirming each write turned the strip into a flashing banner and trained
+ * users to ignore the one place hotkey conflicts and connection failures
+ * appear. Changing a setting must leave the strip alone entirely.
  */
-test('a save confirmation does not blank a later message when it expires', async ({ page, extensionId }) => {
+test('changing a setting says nothing', async ({ page, context, extensionId }) => {
   await setExtensionSettings(page, {
     targetLang: 'en',
     targetLangSetByUser: true,
@@ -123,10 +120,36 @@ test('a save confirmation does not blank a later message when it expires', async
   });
 
   await page.goto(`chrome-extension://${extensionId}/options/options.html`);
+  await page.click('label:has(#showFloatBall)');
+
+  // The write still happens — silence is not "nothing was saved".
+  await expect.poll(async () => getSetting(context, 'showFloatBall')).toBe(false);
+  await expect(page.locator('#statusMessage')).toBeHidden();
+});
+
+/**
+ * One status strip serves connection tests, sign-in, presets and rejected
+ * hotkeys, so the two ways a routine message could trample a connection result
+ * both need pinning.
+ *
+ * First: a success message auto-hides after three seconds, and that timer used
+ * to be left running. Anything that appeared in the meantime got blanked along
+ * with it.
+ */
+test('a success message does not blank a later message when it expires', async ({ page, extensionId }) => {
+  await setExtensionSettings(page, {
+    targetLang: 'en',
+    targetLangSetByUser: true,
+    provider: 'openai',
+    apiKey: '',
+    modelName: 'gpt-4.1-mini',
+  });
+
+  await page.goto(`chrome-extension://${extensionId}/options/options.html`);
 
   // Arms the three-second hide.
-  await page.click('label:has(#showFloatBall)');
-  await expect(page.locator('#statusMessage')).toContainText('Settings Saved');
+  await page.click('.btn-preset');
+  await expect(page.locator('#statusMessage')).toContainText('Preset applied');
 
   // Well inside that window, put something the user must not lose.
   await page.click('#testConnection');
@@ -139,10 +162,10 @@ test('a save confirmation does not blank a later message when it expires', async
 
 /**
  * Second: clicking Test Connection blurs whatever credential field is being
- * edited, so the autosave flush runs concurrently with the probe. The routine
- * "settings saved" must not answer a question the user asked of the API.
+ * edited, so the autosave flush runs concurrently with the probe. That flush
+ * must not answer a question the user asked of the API.
  */
-test('the save confirmation stays quiet while a connection test is in flight', async ({ page, extensionId }) => {
+test('an autosave flush stays quiet while a connection test is in flight', async ({ page, extensionId }) => {
   await setExtensionSettings(page, {
     targetLang: 'en',
     targetLangSetByUser: true,

--- a/test/e2e/fixtures.js
+++ b/test/e2e/fixtures.js
@@ -18,7 +18,13 @@ const test = base.extend({
    */
   context: async ({}, use) => {
     const context = await chromium.launchPersistentContext('', {
-      headless: false, // Extensions require headed mode
+      // Chrome's newer headless shell loads unpacked extensions, so the suite no
+      // longer has to steal window focus and the pointer while it runs. The
+      // `chromium` channel is what selects that shell — the bundled default
+      // build still cannot load extensions headless.
+      // Set HEADED=1 (or `npm run test:headed`) to watch a run.
+      channel: 'chromium',
+      headless: !process.env.HEADED,
       args: [
         `--disable-extensions-except=${extensionPath}`,
         `--load-extension=${extensionPath}`,

--- a/test/e2e/model-selection.spec.js
+++ b/test/e2e/model-selection.spec.js
@@ -1,0 +1,82 @@
+const { test, expect } = require('./fixtures');
+const { setExtensionSettings } = require('./helpers');
+
+async function getSetting(context, key) {
+  let worker = context.serviceWorkers()[0];
+  if (!worker) {
+    worker = await context.waitForEvent('serviceworker');
+  }
+  return worker.evaluate((settingKey) => new Promise((resolve) => {
+    chrome.storage.sync.get([settingKey], (result) => resolve(result[settingKey]));
+  }), key);
+}
+
+async function openOptions(page, extensionId, settings) {
+  await setExtensionSettings(page, {
+    targetLang: 'en',
+    targetLangSetByUser: true,
+    apiKey: 'sk-test',
+    ...settings
+  });
+  await page.goto(`chrome-extension://${extensionId}/options/options.html`);
+  await expect(page.locator('#modelSelect')).toBeVisible();
+}
+
+/**
+ * The dropdown and the free-text box are two controls bound to one setting, and
+ * only one of them can win. Picking from the list already clears the box; the
+ * reverse has to hold too, or the page shows a model that is not the one being
+ * used — the dropdown still displaying the old pick while the request goes out
+ * with the typed name.
+ */
+test('typing a custom model overrides a model picked from the dropdown', async ({ page, context, extensionId }) => {
+  await openOptions(page, extensionId, {
+    provider: 'openrouter',
+    apiEndpoint: 'https://openrouter.ai/api/v1/chat/completions',
+    modelName: ''
+  });
+
+  await page.locator('#modelSelect').selectOption('anthropic/claude-opus-5');
+  await expect.poll(() => getSetting(context, 'modelName')).toBe('anthropic/claude-opus-5');
+
+  await page.locator('#modelName').fill('x-ai/grok-4');
+  await page.locator('#modelName').blur();
+
+  // The typed name is what gets used...
+  await expect.poll(() => getSetting(context, 'modelName')).toBe('x-ai/grok-4');
+  // ...so the dropdown must not keep advertising the model it replaced.
+  await expect(page.locator('#modelSelect')).toHaveValue('');
+});
+
+test('clearing the custom model falls back to the dropdown selection', async ({ page, context, extensionId }) => {
+  await openOptions(page, extensionId, {
+    provider: 'openrouter',
+    apiEndpoint: 'https://openrouter.ai/api/v1/chat/completions',
+    modelName: 'x-ai/grok-4'
+  });
+
+  // A custom name that is not in the list loads into the text box.
+  await expect(page.locator('#modelName')).toHaveValue('x-ai/grok-4');
+  await expect(page.locator('#modelSelect')).toHaveValue('');
+
+  await page.locator('#modelSelect').selectOption('openai/gpt-5.6-luna');
+  await expect(page.locator('#modelName')).toHaveValue('');
+  await expect.poll(() => getSetting(context, 'modelName')).toBe('openai/gpt-5.6-luna');
+});
+
+test('a custom model survives a reload', async ({ page, context, extensionId }) => {
+  await openOptions(page, extensionId, {
+    provider: 'openrouter',
+    apiEndpoint: 'https://openrouter.ai/api/v1/chat/completions',
+    modelName: ''
+  });
+
+  await page.locator('#modelSelect').selectOption('anthropic/claude-opus-5');
+  await page.locator('#modelName').fill('x-ai/grok-4');
+  await page.locator('#modelName').blur();
+  await expect.poll(() => getSetting(context, 'modelName')).toBe('x-ai/grok-4');
+
+  await page.reload();
+  await expect(page.locator('#modelName')).toHaveValue('x-ai/grok-4');
+  await expect(page.locator('#modelSelect')).toHaveValue('');
+});

--- a/test/unit/api-compat.test.mjs
+++ b/test/unit/api-compat.test.mjs
@@ -1,0 +1,204 @@
+// Guards for shared/api-compat.js — the module that decides which parameters
+// each model accepts. These are the rules that break silently when a vendor
+// ships a new generation, so they are asserted rather than eyeballed.
+//
+// Run with: npm run test:unit
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// The module has no `export` (it is also loaded as a classic script by the
+// options page), so importing it for its side effect publishes globalThis.APICompat.
+await import('../../shared/api-compat.js');
+const A = globalThis.APICompat;
+
+const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8');
+const openAIBody = (model, maxTokens = 800, temperature = A.DEFAULT_TEMPERATURE) =>
+  A.buildOpenAIRequestBody(model, [{ role: 'user', content: 'hi' }], maxTokens, temperature);
+
+test('reasoning effort matches what each GPT generation accepts', () => {
+  // gpt-5.6 dropped 'minimal'; sending it returns HTTP 400. This is the
+  // regression that broke gpt-5.6-luna for users.
+  for (const model of ['gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.6']) {
+    assert.equal(openAIBody(model).reasoning_effort, 'none', model);
+  }
+  // Older GPT-5 tiers only know 'minimal'.
+  for (const model of ['gpt-5', 'gpt-5-mini', 'gpt-5.4-mini', 'gpt-5.5']) {
+    assert.equal(openAIBody(model).reasoning_effort, 'minimal', model);
+  }
+  // The o-series accepts neither value.
+  for (const model of ['o1', 'o3', 'o3-mini', 'o4-mini']) {
+    assert.equal('reasoning_effort' in openAIBody(model), false, model);
+  }
+  // Non-reasoning models get no effort control at all.
+  for (const model of ['gpt-4o-mini', 'gpt-4.1-mini', 'deepseek-chat']) {
+    assert.equal('reasoning_effort' in openAIBody(model), false, model);
+  }
+});
+
+test('version comparison is not decimal parsing', () => {
+  // parseFloat('5.10') === 5.1 would put a future gpt-5.10 below gpt-5.6.
+  assert.equal(openAIBody('gpt-5.10').reasoning_effort, 'none');
+});
+
+test('an unreleased major generation lands on the modern parameter shape', () => {
+  // Not a prediction about gpt-6's capabilities — just the safer default, since
+  // max_tokens is rejected outright by reasoning models.
+  const body = openAIBody('gpt-6');
+  assert.ok(body.max_completion_tokens > 0);
+  assert.equal('max_tokens' in body, false);
+  assert.equal('temperature' in body, false);
+  assert.equal(body.reasoning_effort, 'none');
+});
+
+test('reasoning models use max_completion_tokens and no temperature', () => {
+  const body = openAIBody('gpt-5.6-luna');
+  assert.equal('max_tokens' in body, false);
+  assert.ok(body.max_completion_tokens > 0);
+  assert.equal('temperature' in body, false);
+});
+
+test('temperature is sent only where the model still honours it', () => {
+  assert.equal(openAIBody('gpt-4o-mini').temperature, A.DEFAULT_TEMPERATURE);
+  assert.equal(openAIBody('deepseek-chat').temperature, A.DEFAULT_TEMPERATURE);
+  assert.equal(openAIBody('gemini-2.5-flash').temperature, A.DEFAULT_TEMPERATURE);
+  // Gemini 3+ is tuned for its 1.0 default; lowering it can cause looping.
+  assert.equal('temperature' in openAIBody('gemini-3.6-flash'), false);
+  assert.equal('temperature' in openAIBody('gemini-3.5-flash-lite'), false);
+  // Newer Claude models reject temperature even behind an OpenAI gateway.
+  assert.equal('temperature' in openAIBody('claude-opus-5'), false);
+});
+
+test('models that bill hidden tokens get a floor on the output budget', () => {
+  // A single-word lookup asks for 800; hidden reasoning can consume all of it
+  // and return empty text with finish_reason "length".
+  for (const model of ['gpt-5.6-luna', 'o3', 'claude-opus-5', 'gemini-3.6-flash']) {
+    const budget = A.tokenBudgetFor(model, 800);
+    assert.equal(budget, A.REASONING_TOKEN_FLOOR, model);
+  }
+  // Models without hidden spend keep the caller's budget...
+  assert.equal(A.tokenBudgetFor('gpt-4o-mini', 800), 800);
+  // ...and the floor never lowers a budget that is already larger.
+  assert.equal(A.tokenBudgetFor('gpt-5.6-luna', 8000), 8000);
+});
+
+test('gateway-prefixed names are detected like direct ones', () => {
+  // The prefix is kept in `model` (the gateway needs it) but must not hide the
+  // model's capabilities, so every other field has to match.
+  const { model: prefixed, ...viaGateway } = openAIBody('openai/gpt-5.6-luna');
+  const { model: direct, ...viaOpenAI } = openAIBody('gpt-5.6-luna');
+  assert.equal(prefixed, 'openai/gpt-5.6-luna');
+  assert.equal(direct, 'gpt-5.6-luna');
+  assert.deepEqual(viaGateway, viaOpenAI);
+
+  assert.equal('temperature' in openAIBody('google/gemini-3.6-flash'), false);
+  assert.equal('temperature' in openAIBody('anthropic/claude-opus-5'), false);
+});
+
+test('every catalogued model produces a well-formed request', () => {
+  for (const [key, provider] of Object.entries(A.PROVIDERS)) {
+    for (const model of provider.models) {
+      const body = openAIBody(model);
+      const label = `${key}/${model}`;
+      // Exactly one token-limit field, or the vendor rejects the request.
+      assert.equal(
+        ('max_tokens' in body) !== ('max_completion_tokens' in body),
+        true,
+        `${label} must set exactly one token-limit field`
+      );
+      if ('reasoning_effort' in body) {
+        // 'minimal' was removed in gpt-5.6; anything newer must not send it.
+        assert.ok(
+          ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'].includes(body.reasoning_effort),
+          `${label} sent an unknown reasoning_effort: ${body.reasoning_effort}`
+        );
+        assert.equal(
+          body.reasoning_effort === 'minimal' && A.versionAtLeast(model, 'gpt', 5, 6),
+          false,
+          `${label} must not send 'minimal' — gpt-5.6+ rejects it`
+        );
+      }
+    }
+  }
+});
+
+test('catalog defaults point at a model in their own list', () => {
+  for (const [key, provider] of Object.entries(A.PROVIDERS)) {
+    if (!provider.defaultModel) continue;
+    assert.ok(
+      provider.models.includes(provider.defaultModel),
+      `${key}.defaultModel "${provider.defaultModel}" is not in ${key}.models`
+    );
+  }
+});
+
+test('catalog lists no retired models', () => {
+  // Append here as vendors retire ids, so they cannot be reintroduced.
+  const retired = [
+    'claude-opus-4-1',      // retires 2026-08-05
+    'anthropic/claude-opus-4.1',
+    'gemini-2.0-flash',     // shut down 2026-06-01
+    'gemini-2.0-flash-lite',
+    'gemini-3-flash',       // never reached stable
+    'gemini-3-pro',         // 3.x Pro is preview-only
+    'google/gemini-3-flash',
+    'google/gemini-3-pro'
+  ];
+  for (const [key, provider] of Object.entries(A.PROVIDERS)) {
+    for (const model of provider.models) {
+      assert.equal(retired.includes(model), false, `${key} still lists retired model ${model}`);
+    }
+  }
+});
+
+test('no consumer re-declares the shared capability logic', () => {
+  // The gpt-5.6 breakage needed fixing in two places because background.js and
+  // options.js each carried a copy. Keep it that way: exactly one definition.
+  const shared = ['buildOpenAIRequestBody', 'buildClaudeRequestBody', 'tokenBudgetFor',
+    'isOpenAIReasoningModel', 'minimalReasoningEffort', 'isClaudeAPI', 'parseAPIError'];
+  for (const file of ['background/background.js', 'options/options.js']) {
+    const src = repoFile(file);
+    for (const name of shared) {
+      assert.equal(
+        src.includes(`function ${name}(`),
+        false,
+        `${file} re-declares ${name} — it belongs to shared/api-compat.js alone`
+      );
+    }
+  }
+});
+
+test('the options page loads the shared module before its own script', () => {
+  const html = repoFile('options/options.html');
+  const shared = html.indexOf('shared/api-compat.js');
+  const own = html.indexOf('options.js');
+  assert.ok(shared !== -1, 'options.html must load shared/api-compat.js');
+  assert.ok(shared < own, 'shared/api-compat.js must load before options.js');
+});
+
+test('the packaged zip includes the shared module', () => {
+  const pkg = JSON.parse(repoFile('package.json'));
+  assert.match(pkg.scripts.zip, /\bshared\/\s/, 'npm run zip must package shared/');
+});
+
+test('vendor error shapes are all recognised', () => {
+  const openai = A.readAPIResponse({ error: { message: 'bad key', code: 401 } }, 401, false, false);
+  assert.match(openai.error, /bad key/);
+  // Known statuses get an explanation prepended.
+  assert.match(openai.error, /API Key/);
+
+  const anthropic = A.readAPIResponse(
+    { type: 'error', error: { type: 'invalid_request_error', message: 'bad model' } }, 400, false, true);
+  assert.match(anthropic.error, /bad model/);
+
+  const ollama = A.readAPIResponse({ error: 'model not found' }, 404, false, false);
+  assert.match(ollama.error, /model not found/);
+
+  // OpenRouter reports some failures with HTTP 200 and an error payload.
+  const soft = A.readAPIResponse({ error: { message: 'rate limited' } }, 200, true, false);
+  assert.match(soft.error, /rate limited/);
+
+  assert.equal(A.readAPIResponse({ choices: [{ message: { content: ' hi ' } }] }, 200, true, false).text, 'hi');
+  assert.equal(A.readAPIResponse({ content: [{ text: ' hi ' }] }, 200, true, true).text, 'hi');
+});


### PR DESCRIPTION
## Why

Configuring `gpt-5.6-luna` failed with an HTTP 400 naming `reasoning_effort`.

Root cause: the request builder gated `reasoning_effort: "minimal"` on `/^gpt-5/`, which matches `gpt-5.6-*`. GPT-5.6 removed `minimal` — its floor is now `none`.

The deeper problem was structural. `background/background.js` and `options/options.js` each carried their own copy of the provider catalog, the per-model parameter rules and the vendor error parser. So one vendor change broke translation and the **Test Connection** button independently, needed two separate fixes, and — worse — a passing connection test was never evidence that translation would work, because the probe built its own request body.

## What changed

### `shared/api-compat.js` — one owner for every model/provider shape decision

Loaded by the service worker as an ESM side-effect import and by the options page as a classic script (IIFE publishing `globalThis.APICompat`). `background.js` drops 232 lines to 50; `options.js` loses its `PROVIDERS` literal and now probes with the exact builders translation uses.

Rules encoded, verified against vendor docs:

- `reasoning_effort` floor is `minimal` for gpt-5…gpt-5.5, `none` from gpt-5.6; the o-series accepts neither
- reasoning models use `max_completion_tokens` and reject an explicit `temperature`
- **Gemini 3+ must not receive `temperature`** — Google's guidance is to keep the 1.0 default; lowering it can cause looping
- Claude models reject `temperature`, including behind an OpenAI-compatible gateway
- models that bill hidden reasoning/thinking tokens get a floor on the output budget, or short calls return empty text with `finish_reason: "length"`
- version comparison splits major/minor, so a future `gpt-5.10` sorts above `gpt-5.6` rather than being read as the decimal `5.1`

Catalog fixes found while auditing: `gemini.defaultModel` pointed at `gemini-3-flash`, which never shipped as a stable id; retired ids removed (`claude-opus-4-1`, `gemini-2.0-*`, `gemini-3-pro`).

### E2E runs headless

The fixture's `headless: false` carried the comment "Extensions require headed mode". That stopped being true once Chrome's newer headless shell landed — every local run was grabbing window focus and the pointer for ~6 minutes for no reason. `channel: 'chromium'` is the part that matters: Playwright's bundled default build still cannot load an unpacked extension headless. `HEADED=1` (or `npm run test:headed`) still opens a window.

### Two options-page fixes from manual testing

- **Every change announced "Settings Saved".** Autosave writes on every keystroke, so the strip flashed constantly with the one thing the user already knew — and that strip is also where hotkey conflicts and connection failures appear. Now silent on success; errors untouched.
- **Typing a custom model after picking one from the dropdown looked like it did nothing.** The write was correct all along — storage held the typed name — but the dropdown went on displaying the model it had replaced, so the page asserted two different models with nothing to say which was live. Only half the handoff existed: picking from the list cleared the text box, but typing never released the list. Added the mirror handler.

## Tests

New `npm run test:unit` — 14 cases, no browser, ~0.2s. It locks the rules that fail *silently* on a vendor change: every catalogued model must produce exactly one token-limit field, no gpt-5.6+ model may send `minimal`, defaults must exist in their own list, retired ids stay out, `options.html` must load the shared module first, `npm run zip` must package `shared/`, and **`background.js`/`options.js` must not re-declare any shared function** — so the duplication that caused this cannot come back.

New `test/e2e/model-selection.spec.js` covers the dropdown/custom-model handoff in both directions plus the reload path.

## Verification

- unit: 14/14 pass
- e2e: 68 passed, 9 skipped, 9 failed — all 9 failures reproduce identically on `1ab2779` (this PR's merge-base), so none are regressions. They are: hover-translation ×2, input-translation, page-translation-highlight-class, page-translation-inline-skip, youtube-caption-translation ×4.
- `npm run zip` confirmed to include `shared/api-compat.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
