### PR TITLE
fix: a device with no account shows comic and PDF translation as off

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,34 @@ No build step required - the extension loads directly in Chrome as an unpacked e
 - **Storage**: Chrome sync storage for cross-device settings
 - **Theming**: CSS variables for dark/light theme support
 
+### Account-Backed Features
+
+Comic translation and PDF translation are the two features that do NOT use the
+user's own API key: they run on our servers against a monthly free page
+allowance, so both require a signed-in account. That makes their switches a
+preference with a precondition, and the two halves live in different storage
+areas on purpose:
+
+| what | where | scope |
+| --- | --- | --- |
+| `enableComicTranslation` / `enablePdfTranslation` | `chrome.storage.sync` | per account |
+| `comicToken` | `chrome.storage.local` | per device |
+
+**A device with no token has both features off, whatever sync says.** That
+answer is derived on every read by `shared/account-gate.js` — never written back
+to sync. A new install syncs the switches down before it has ever signed in
+(PDF ships on), so a signed-out device that "corrected" the preference would
+reach across and disable the feature on the device that is still signed in.
+
+Every surface that reads either switch must run it through
+`AccountGate.applyAccountGate()` first: the options page, the popup, the content
+scripts and the service worker's context menu entries all do, and
+`npm run test:unit` asserts each of them loads the module. The one deliberate
+exception is `assertFeatureEnabled()` in `background.js`, which judges the raw
+switch — the account half is enforced one layer down, where `apiFetch` answers a
+create with no token as `unauthorized`, and every surface turns that into a
+sign-in offer.
+
 ### API Compatibility
 
 Works with any OpenAI Chat Completions-compatible API, plus Anthropic's native

--- a/background/background.js
+++ b/background/background.js
@@ -1,5 +1,6 @@
 // AI Translator Background Script
 import '../shared/api-compat.js';
+import '../shared/account-gate.js';
 import '../i18n/messages.js';
 import * as comicClient from './comic-client.js';
 import * as pdfClient from './pdf-client.js';
@@ -41,10 +42,17 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
     refreshContextMenuTitles();
   }
   if (namespace === 'sync' && changes.enableComicTranslation) {
-    refreshComicMenuVisibility(changes.enableComicTranslation.newValue);
+    refreshComicMenuVisibility();
   }
   if (namespace === 'sync' && changes.enablePdfTranslation) {
-    refreshPdfMenuVisibility(changes.enablePdfTranslation.newValue);
+    refreshPdfMenuVisibility();
+  }
+  // Both entries are gated on the account as well as the switch, so signing in
+  // or out has to re-run the same check. Without this a sign-out leaves menu
+  // entries for two features this device can no longer run.
+  if (namespace === 'local' && changes[AccountGate.TOKEN_KEY]) {
+    refreshComicMenuVisibility();
+    refreshPdfMenuVisibility();
   }
 });
 
@@ -303,13 +311,24 @@ function createContextMenus() {
 }
 
 /**
- * Show or hide the comic entry. Called on every menu rebuild and whenever the
- * setting changes, so the menu never outlives the preference that justified it.
+ * Settings with the account gate applied — the only shape the rest of this
+ * worker should judge the two server-backed features from. See
+ * shared/account-gate.js.
  */
-async function refreshComicMenuVisibility(enabled) {
-  const visible = enabled !== undefined
-    ? !!enabled
-    : (await chrome.storage.sync.get(defaultSettings)).enableComicTranslation;
+async function getGatedSettings() {
+  return AccountGate.applyAccountGate(await chrome.storage.sync.get(defaultSettings));
+}
+
+/**
+ * Show or hide the comic entry. Called on every menu rebuild and whenever the
+ * setting or the account changes, so the menu never outlives the preference —
+ * or the sign-in — that justified it.
+ *
+ * Re-read rather than handed the new value: the answer depends on the switch
+ * AND the token, so a changed switch is only half of it.
+ */
+async function refreshComicMenuVisibility() {
+  const visible = (await getGatedSettings()).enableComicTranslation;
   chrome.contextMenus.update(MENU_IDS.translateComicImage, { visible: !!visible })
     // The menu is gone during a rebuild; the rebuild itself will re-apply this.
     .catch(() => {});
@@ -318,10 +337,8 @@ async function refreshComicMenuVisibility(enabled) {
 }
 
 /** Same contract as refreshComicMenuVisibility, for the PDF entries. */
-async function refreshPdfMenuVisibility(enabled) {
-  const visible = enabled !== undefined
-    ? !!enabled
-    : (await chrome.storage.sync.get(defaultSettings)).enablePdfTranslation;
+async function refreshPdfMenuVisibility() {
+  const visible = (await getGatedSettings()).enablePdfTranslation;
   chrome.contextMenus.update(MENU_IDS.translatePdfLink, { visible: !!visible })
     .catch(() => {});
   chrome.contextMenus.update(MENU_IDS.translatePdfPage, { visible: !!visible })
@@ -337,6 +354,12 @@ async function refreshPdfMenuVisibility(enabled) {
  * is the one point both features funnel through, so it is the only place the
  * answer can be relied on; without it a switched-off feature can still upload a
  * document and spend the month's allowance.
+ *
+ * Reads the raw switch, NOT getGatedSettings(): the account half of the gate is
+ * already enforced one layer down, where apiFetch answers a create with no
+ * token as `unauthorized` — and every surface turns that into a sign-in offer.
+ * Answering `feature_disabled` instead would name the wrong problem and leave
+ * the user nothing to do about it.
  */
 async function assertFeatureEnabled(key) {
   const settings = await chrome.storage.sync.get(defaultSettings);

--- a/content/content-bootstrap.js
+++ b/content/content-bootstrap.js
@@ -167,6 +167,12 @@
         theme: 'light'
       });
     }
+    // After both branches, so the fallback above cannot leave PDF translation
+    // on either. Comic and PDF translation need an account this device may not
+    // have; applied once here so every consumer of ctx.settings — the float
+    // ball menu, the comic overlay — reads a switch that is true only when the
+    // feature can actually run. See shared/account-gate.js.
+    await AccountGate.applyAccountGate(ctx.settings);
     console.log('AI Translator: Settings loaded', {
       showFloatBall: ctx.settings.showFloatBall,
       theme: ctx.settings.theme
@@ -175,11 +181,25 @@
 
   ctx.setupStorageListener = function() {
     chrome.storage.onChanged.addListener((changes, namespace) => {
+      // The account token is per device and lives in local storage, and it is
+      // half of whether comic and PDF translation are on. Signing in or out
+      // therefore changes the answer without any sync key moving — re-derive it
+      // from what sync already holds rather than mirror the token here.
+      if (namespace === 'local' && changes[AccountGate.TOKEN_KEY]) {
+        ctx.loadSettings();
+        return;
+      }
       if (namespace !== 'sync') return;
 
       Object.keys(changes).forEach((key) => {
         ctx.settings[key] = changes[key].newValue;
       });
+      // A switch synced down from a device that IS signed in must not turn the
+      // feature on here. Not awaited — the listener is synchronous and the only
+      // readers are menus built on a later user gesture.
+      if (AccountGate.ACCOUNT_FEATURE_KEYS.some((key) => key in changes)) {
+        AccountGate.applyAccountGate(ctx.settings);
+      }
 
       if (changes.showFloatBall) {
         console.log('AI Translator: Storage changed, showFloatBall:', changes.showFloatBall.oldValue, '->', changes.showFloatBall.newValue);

--- a/manifest.json
+++ b/manifest.json
@@ -52,6 +52,7 @@
       ],
       "js": [
         "i18n/messages.js",
+        "shared/account-gate.js",
         "content/content-bootstrap.js",
         "content/content-utils.js",
         "content/content-language.js",

--- a/options/options.html
+++ b/options/options.html
@@ -516,6 +516,7 @@
   </div>
 
   <script src="../shared/api-compat.js"></script>
+  <script src="../shared/account-gate.js"></script>
   <script src="../i18n/messages.js"></script>
   <!-- 内置引擎的语言码映射、可用性查询和首次下载都在这里；设置页复用同一份实现，
        避免和 content script 各写一套语言码映射后慢慢走偏。 -->

--- a/options/options.js
+++ b/options/options.js
@@ -428,9 +428,19 @@ function showComicState(name) {
   elements.comicSignedIn.classList.toggle('hidden', name !== 'signedIn');
 }
 
-/** True once the service has confirmed a signed-in account. Read by the two
- *  feature toggles, which must not turn on without one. */
-let comicSignedIn = false;
+/**
+ * Whether this device has an account: true, false, or null while the answer is
+ * outstanding or the service could not be reached.
+ *
+ * Three states rather than two because the two feature switches render from it.
+ * Collapsing "not answered yet" into "signed out" would flash both switches off
+ * on every load for the signed-in majority; collapsing it into "signed in"
+ * would show a signed-out user a switch that is about to retract. Unknown
+ * renders the stored preference and corrects itself, which for a signed-out
+ * device is a message round-trip — getAccount() answers `{signedIn: false}` off
+ * the local token without touching the network.
+ */
+let comicSignedIn = null;
 
 /** The initial account fetch, so the sign-in gate can wait on it instead of
  *  reading a `comicSignedIn` that has not been answered yet. Never rejects. */
@@ -444,6 +454,41 @@ let comicAccountGeneration = 0;
 
 /** The sign-in flow currently running, shared by both switches' gates. */
 let comicSignInInFlight = null;
+
+/**
+ * The stored preference behind each account-backed switch, kept apart from what
+ * the checkbox shows.
+ *
+ * These two are the only settings on the page whose displayed state is not
+ * simply what storage says: both features run on our servers against a monthly
+ * allowance, so a device with no account cannot have them on however the
+ * preference arrived — and it arrives on every new install, because the
+ * switches sync and the token does not.
+ *
+ * The preference itself is left alone rather than corrected. Writing false from
+ * a signed-out device would sync back and turn the feature off on the device
+ * that is still signed in, which is not what "sign out here" asked for. See
+ * shared/account-gate.js, which derives the same answer for every other
+ * surface.
+ */
+let storedComicEnabled = false;
+let storedPdfEnabled = false;
+
+/**
+ * Draw the two switches from preference AND account.
+ *
+ * Called on load and on every account transition, so the switches can never sit
+ * on for a feature this device cannot run. `comicSignedIn === null` means the
+ * answer is still outstanding — see the declaration.
+ */
+function renderAccountFeatures() {
+  const comicOn = storedComicEnabled && comicSignedIn !== false;
+  const pdfOn = storedPdfEnabled && comicSignedIn !== false;
+  elements.enableComicTranslation.checked = comicOn;
+  elements.comicTargetLang.disabled = !comicOn;
+  elements.enablePdfTranslation.checked = pdfOn;
+  elements.pdfTargetLang.disabled = !pdfOn;
+}
 
 /** Pages left this month for one operation. Older servers report only the comic
  *  allowance, at the top level and under its pre-PDF name. */
@@ -484,11 +529,15 @@ async function refreshComicAccount({ force = false, quiet = false } = {}) {
     // account that is gone.
     if (response && response.error && response.error.code === 'unauthorized') {
       comicSignedIn = false;
+      renderAccountFeatures();
       showComicState('signedOut');
       return;
     }
     if (quiet) return;
-    comicSignedIn = false;
+    // Unreachable, not signed out. The switches keep showing the preference
+    // rather than retracting on a service outage the user did not cause; the
+    // gate still asks for a sign-in before either can be turned on.
+    comicSignedIn = null;
     elements.comicAccountLoading.textContent = t('comicAccountError');
     showComicState('loading');
     return;
@@ -501,11 +550,13 @@ async function refreshComicAccount({ force = false, quiet = false } = {}) {
 function showAccount(account) {
   if (!account.signedIn) {
     comicSignedIn = false;
+    renderAccountFeatures();
     showComicState('signedOut');
     return false;
   }
 
   comicSignedIn = true;
+  renderAccountFeatures();
   elements.comicEmail.textContent = account.user?.email || account.user?.name || '';
   // Pages left this month, per feature: the product is free, so a balance would
   // be answering a question nobody is asking.
@@ -543,6 +594,7 @@ async function runComicSignIn() {
 
   if (!response || !response.ok) {
     comicSignedIn = false;
+    renderAccountFeatures();
     if (response?.error?.code !== 'sign_in_cancelled') {
       showStatus(response?.error?.message || t('comicSignInFailed'), 'error');
     }
@@ -560,17 +612,17 @@ async function comicSignOut() {
   comicAccountGeneration += 1;
   await chrome.runtime.sendMessage({ type: 'COMIC_SIGN_OUT' });
   comicSignedIn = false;
-  showComicState('signedOut');
-  // The two switches are deliberately left alone. They live in sync storage
-  // and the token lives in local, so writing them off here would reach across
-  // to every other device the account is signed in on and disable the feature
-  // there — a sign-out is about this device's credential, nothing more.
+  // Both switches go off with the token: neither feature can run on a device
+  // with no account, so leaving one on would be a switch that promises a
+  // sign-in prompt rather than a translation.
   //
-  // What is left is a switch that is on with no token behind it. That is the
-  // same state a second device is in the moment it syncs the preference, and
-  // it is not a dead end: every entry point ends at a sign-in offer rather
-  // than an error — the comic overlay prompts and retries the job, and the PDF
-  // page has its own Sign In button.
+  // The stored preference behind them is deliberately NOT written off. It lives
+  // in sync storage while the token lives in local, so clobbering it here would
+  // reach across to every other device the account is still signed in on and
+  // disable the feature there — a sign-out is about this device's credential,
+  // nothing more. Signing back in restores what the user had.
+  renderAccountFeatures();
+  showComicState('signedOut');
 }
 
 /**
@@ -584,14 +636,17 @@ async function comicSignOut() {
 async function requireAccountFor(checkbox) {
   if (!checkbox.checked) return true;
   // The switches are live from the first paint, while the account request is
-  // still on the wire and `comicSignedIn` is merely at its initial false. A
+  // still on the wire and `comicSignedIn` is merely at its initial null. A
   // click landing in that window would open an authentication tab at someone
   // who is already signed in, so wait for the answer before believing it.
   await comicAccountReady;
   if (comicSignedIn) return true;
   const signedIn = await comicSignIn();
   if (!signedIn) {
-    checkbox.checked = false;
+    // Back to preference-AND-account, which with no account is off. The failed
+    // sign-in itself has already rendered that; this covers the checkbox the
+    // user just clicked in the same pass.
+    renderAccountFeatures();
     showStatus(t('accountRequired'), 'error');
   }
   return signedIn;
@@ -643,12 +698,13 @@ async function loadSettings() {
     elements.hoverTranslationHotkey.value = result.hoverTranslationHotkey || 'Shift';
     elements.showFloatBall.checked = result.showFloatBall;
     elements.autoDetect.checked = result.autoDetect;
-    elements.enableComicTranslation.checked = !!result.enableComicTranslation;
+    // The switches themselves are drawn by renderAccountFeatures, which also
+    // weighs whether this device has the account both features need.
+    storedComicEnabled = !!result.enableComicTranslation;
+    storedPdfEnabled = !!result.enablePdfTranslation;
     elements.comicTargetLang.value = result.comicTargetLang || '';
-    elements.comicTargetLang.disabled = !result.enableComicTranslation;
-    elements.enablePdfTranslation.checked = !!result.enablePdfTranslation;
     elements.pdfTargetLang.value = result.pdfTargetLang || '';
-    elements.pdfTargetLang.disabled = !result.enablePdfTranslation;
+    renderAccountFeatures();
     elements.enableYoutubeCaptionTranslation.checked = !!result.enableYoutubeCaptionTranslation;
     elements.showYoutubeOriginalCaption.checked = result.showYoutubeOriginalCaption !== false;
     elements.youtubeCaptionFontColor.value = result.youtubeCaptionFontColor || '#ffffff';
@@ -1249,16 +1305,29 @@ function setupEventListeners() {
   });
 }
 
-/** `gate` is set only by the switch's own change event — see setupEventListeners. */
+/**
+ * `gate` is set only by the switch's own change event — see setupEventListeners.
+ *
+ * Only a gated call moves the preference. The language select shares this
+ * handler and must write the pair without touching the switch: it can be
+ * reached while the account answer is still outstanding, and reading the
+ * checkbox there would persist a switch that is merely mid-render.
+ */
 async function saveComicSettings({ gate = false } = {}) {
-  // Sign-in first: requireAccountFor may clear the checkbox, and what gets
-  // written has to be what the checkbox ends up saying.
-  if (gate) await requireAccountFor(elements.enableComicTranslation);
-  const enabled = elements.enableComicTranslation.checked;
-  elements.comicTargetLang.disabled = !enabled;
+  if (gate) {
+    // Read before the gate, not after: a successful sign-in redraws both
+    // switches from the stored preference, which does not yet include the click
+    // being handled here.
+    const wanted = elements.enableComicTranslation.checked;
+    // A refused sign-in leaves the preference exactly as it was — writing false
+    // would sync across and disable the feature on a device that is signed in.
+    if (!(await requireAccountFor(elements.enableComicTranslation))) return;
+    storedComicEnabled = wanted;
+    renderAccountFeatures();
+  }
   try {
     await chrome.storage.sync.set({
-      enableComicTranslation: enabled,
+      enableComicTranslation: storedComicEnabled,
       comicTargetLang: elements.comicTargetLang.value
     });
   } catch (error) {
@@ -1269,13 +1338,17 @@ async function saveComicSettings({ gate = false } = {}) {
   }
 }
 
+/** See saveComicSettings — same contract, same reasons. */
 async function savePdfSettings({ gate = false } = {}) {
-  if (gate) await requireAccountFor(elements.enablePdfTranslation);
-  const enabled = elements.enablePdfTranslation.checked;
-  elements.pdfTargetLang.disabled = !enabled;
+  if (gate) {
+    const wanted = elements.enablePdfTranslation.checked;
+    if (!(await requireAccountFor(elements.enablePdfTranslation))) return;
+    storedPdfEnabled = wanted;
+    renderAccountFeatures();
+  }
   try {
     await chrome.storage.sync.set({
-      enablePdfTranslation: enabled,
+      enablePdfTranslation: storedPdfEnabled,
       pdfTargetLang: elements.pdfTargetLang.value
     });
   } catch (error) {

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -110,6 +110,7 @@
   </div>
 
   <script src="../i18n/messages.js"></script>
+  <script src="../shared/account-gate.js"></script>
   <script src="../pdf/pdf-ui.js"></script>
   <script src="popup.js"></script>
 </body>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -64,13 +64,15 @@ document.addEventListener('DOMContentLoaded', async () => {
  *
  * Purely a storage read: the account, its sign-in state and the monthly
  * allowance are all reported in Settings now, so the popup no longer waits on a
- * network round-trip to draw a list of buttons. A signed-out user who clicks
- * one is offered sign-in by the overlay that starts the job.
+ * network round-trip to draw a list of buttons. The local token is enough to
+ * know whether this device has an account at all — see shared/account-gate.js.
  */
 async function refreshComicSection() {
   // Off means gone, not greyed out: these rows would otherwise advertise a
   // feature with no entry point behind it.
-  const { enableComicTranslation } = await chrome.storage.sync.get({ enableComicTranslation: false });
+  const { enableComicTranslation } = await AccountGate.applyAccountGate(
+    await chrome.storage.sync.get({ enableComicTranslation: false })
+  );
   elements.comicTranslatePage.hidden = !enableComicTranslation;
   elements.comicColorizePage.hidden = !enableComicTranslation;
 }
@@ -111,7 +113,9 @@ let pdfPollTimer = null;
 let pdfInlineError = null;
 
 async function refreshPdfSection() {
-  const { enablePdfTranslation } = await chrome.storage.sync.get({ enablePdfTranslation: true });
+  const { enablePdfTranslation } = await AccountGate.applyAccountGate(
+    await chrome.storage.sync.get({ enablePdfTranslation: true })
+  );
   if (!enablePdfTranslation) {
     elements.pdfTranslateCurrent.hidden = true;
     elements.pdfTranslateLocal.hidden = true;

--- a/shared/account-gate.js
+++ b/shared/account-gate.js
@@ -1,0 +1,63 @@
+// AI Translator — the account gate for the two server-backed features.
+//
+// Comic translation and PDF translation do not use the user's own API key: they
+// run on our servers against a monthly free page allowance, so both require a
+// signed-in account. That makes their switches a preference with a
+// precondition, and the two live in different storage areas on purpose:
+//
+//   enableComicTranslation / enablePdfTranslation   chrome.storage.sync   (per account)
+//   comicToken                                      chrome.storage.local  (per device)
+//
+// A device with no token cannot run either feature, so it must not show them as
+// on, hide-nothing entry points, or accept a job for them. That answer is
+// DERIVED here on every read rather than written back to sync: a new install
+// syncs the switches down before it has ever signed in, so a signed-out device
+// that "corrected" the preference would reach across and turn the feature off
+// on the device that is still signed in.
+//
+// Loaded as a classic script by the popup, the options page and the content
+// scripts, and as a side-effect import by the module service worker, so it
+// publishes onto the global object rather than using `export`.
+(function (root) {
+  'use strict';
+
+  // Written by comic-client.js saveToken/clearToken. Expiry is deliberately not
+  // considered here — see getToken() there: the server's 401 is what retires a
+  // token, because a wrong local clock must not lock a user out.
+  const TOKEN_KEY = 'comicToken';
+
+  // The two switches this gate governs. Both features share one account, so
+  // they share one precondition.
+  const ACCOUNT_FEATURE_KEYS = ['enableComicTranslation', 'enablePdfTranslation'];
+
+  /** Whether this device holds a credential for the translation service. */
+  async function hasAccount() {
+    try {
+      const stored = await chrome.storage.local.get({ [TOKEN_KEY]: '' });
+      return !!stored[TOKEN_KEY];
+    } catch (error) {
+      // Only a torn-down extension context lands here, and "no account" is the
+      // answer that fails closed.
+      return false;
+    }
+  }
+
+  /**
+   * Force the account-backed switches off when this device has no account.
+   *
+   * Mutates and returns `settings` — every caller already holds the object it
+   * read out of sync storage, and the point is that no caller ever sees the
+   * ungated value.
+   */
+  async function applyAccountGate(settings) {
+    if (!settings) return settings;
+    // Nothing to gate when both are already off, and that is the common case —
+    // worth skipping the storage read on every settings load for.
+    if (!ACCOUNT_FEATURE_KEYS.some(key => settings[key])) return settings;
+    if (await hasAccount()) return settings;
+    ACCOUNT_FEATURE_KEYS.forEach(key => { settings[key] = false; });
+    return settings;
+  }
+
+  root.AccountGate = { TOKEN_KEY, ACCOUNT_FEATURE_KEYS, hasAccount, applyAccountGate };
+})(globalThis);

--- a/test/e2e/comic-account.spec.js
+++ b/test/e2e/comic-account.spec.js
@@ -258,31 +258,44 @@ test.describe('Comic translation switch', () => {
     }
   });
 
+  // The entry follows BOTH halves of the answer: the switch and the account.
+  // Signing out has to retract it even though no sync key moved.
   test('shows and hides the image context menu entry', async ({ context }) => {
-    const worker = await serviceWorker(context);
-    // chrome.contextMenus has no read API, so the call the worker makes is the
-    // only observable. Record it, then flip the setting the way options does.
-    await worker.evaluate(async () => {
-      globalThis.__menuUpdates = [];
-      const original = chrome.contextMenus.update.bind(chrome.contextMenus);
-      chrome.contextMenus.update = (id, props, cb) => {
-        globalThis.__menuUpdates.push({ id, visible: props && props.visible });
-        return original(id, props, cb);
-      };
-      await chrome.storage.sync.set({ enableComicTranslation: false });
-    });
+    const service = await startMockService();
+    try {
+      const worker = await connectExtension(context, service.base, { enabled: false });
+      // chrome.contextMenus has no read API, so the call the worker makes is the
+      // only observable. Record it, then flip the setting the way options does.
+      await worker.evaluate(() => {
+        globalThis.__menuUpdates = [];
+        const original = chrome.contextMenus.update.bind(chrome.contextMenus);
+        chrome.contextMenus.update = (id, props, cb) => {
+          globalThis.__menuUpdates.push({ id, visible: props && props.visible });
+          return original(id, props, cb);
+        };
+      });
 
-    const visibilityCalls = () => worker.evaluate(() => globalThis.__menuUpdates
-      .filter(u => u.id === 'translate-comic-image' && u.visible !== undefined)
-      .map(u => u.visible));
+      const visibilityCalls = () => worker.evaluate(() => globalThis.__menuUpdates
+        .filter(u => u.id === 'translate-comic-image' && u.visible !== undefined)
+        .map(u => u.visible));
 
-    await worker.evaluate(() => chrome.storage.sync.set({ enableComicTranslation: true }));
-    await expect.poll(visibilityCalls).toContain(true);
+      await worker.evaluate(() => chrome.storage.sync.set({ enableComicTranslation: true }));
+      await expect.poll(visibilityCalls).toContain(true);
 
-    await worker.evaluate(() => chrome.storage.sync.set({ enableComicTranslation: false }));
-    await expect.poll(async () => (await visibilityCalls()).at(-1)).toBe(false);
+      // Signed out with the switch untouched: the entry goes anyway.
+      await worker.evaluate(() => chrome.storage.local.remove('comicToken'));
+      await expect.poll(async () => (await visibilityCalls()).at(-1)).toBe(false);
 
-    await worker.evaluate(() => { delete globalThis.__menuUpdates; });
+      await worker.evaluate(() => chrome.storage.local.set({ comicToken: 'test-token' }));
+      await expect.poll(async () => (await visibilityCalls()).at(-1)).toBe(true);
+
+      await worker.evaluate(() => chrome.storage.sync.set({ enableComicTranslation: false }));
+      await expect.poll(async () => (await visibilityCalls()).at(-1)).toBe(false);
+
+      await worker.evaluate(() => { delete globalThis.__menuUpdates; });
+    } finally {
+      await service.close();
+    }
   });
 });
 
@@ -314,17 +327,17 @@ test.describe('Advanced Settings login gate', () => {
   });
 
   // The gate belongs to the switch, not to the card. Both controls persist the
-  // same pair of keys, so a language select that ran the gate would ask a
-  // signed-out user to sign in for picking a language — and turn the feature
-  // off if they declined. PDF is the case that bites: it ships ON, so a user
-  // who has never signed in still reaches this handler.
-  test('picking a language while signed out neither prompts nor disables the feature', async ({ context, page, extensionId }) => {
-    const service = await startMockService({ connect: 'no-token' });
+  // same pair of keys, so a language select that ran the gate would ask for a
+  // sign-in over picking a language — and turn the feature off if it were
+  // declined. It must also not carry the switch along: the select writes the
+  // stored preference, never whatever the checkbox happens to be showing.
+  test('picking a language never prompts for sign-in or moves the switch', async ({ context, page, extensionId }) => {
+    const service = await startMockService();
     try {
-      const worker = await connectExtension(context, service.base, { withToken: false, enabled: false });
+      const worker = await connectExtension(context, service.base, { enabled: false });
       await worker.evaluate(() => chrome.storage.sync.set({ enablePdfTranslation: true, pdfTargetLang: '' }));
       await page.goto(`chrome-extension://${extensionId}/options/options.html`);
-      await expect(page.locator('#comicSignedOut')).toBeVisible();
+      await expect(page.locator('#comicSignedIn')).toBeVisible();
       await expect(page.locator('#enablePdfTranslation')).toBeChecked();
 
       await page.locator('#pdfTargetLang').selectOption('ja');
@@ -334,6 +347,34 @@ test.describe('Advanced Settings login gate', () => {
       )).toEqual({ enablePdfTranslation: true, pdfTargetLang: 'ja' });
       await expect(page.locator('#enablePdfTranslation')).toBeChecked();
       // No sign-in tab was opened on the way.
+      expect(service.state.connectRequests).toBe(0);
+    } finally {
+      await service.close();
+    }
+  });
+
+  // The state a signed-out device is in the moment sync delivers a preference
+  // from a device that is signed in. Both features run on our servers, so this
+  // one cannot have them on — and must not answer by writing the preference off
+  // and syncing that back to the device that can.
+  test('a synced-on switch stays off while this device has no account', async ({ context, page, extensionId }) => {
+    const service = await startMockService({ connect: 'no-token' });
+    try {
+      const worker = await connectExtension(context, service.base, { withToken: false, enabled: true });
+      await worker.evaluate(() => chrome.storage.sync.set({ enablePdfTranslation: true }));
+      await page.goto(`chrome-extension://${extensionId}/options/options.html`);
+      await expect(page.locator('#comicSignedOut')).toBeVisible();
+
+      await expect(page.locator('#enableComicTranslation')).not.toBeChecked();
+      await expect(page.locator('#enablePdfTranslation')).not.toBeChecked();
+      await expect(page.locator('#comicTargetLang')).toBeDisabled();
+      await expect(page.locator('#pdfTargetLang')).toBeDisabled();
+
+      // Rendering it off is not the same as answering it off.
+      expect(await worker.evaluate(
+        () => chrome.storage.sync.get({ enableComicTranslation: false, enablePdfTranslation: false }),
+      )).toEqual({ enableComicTranslation: true, enablePdfTranslation: true });
+      // And nothing about drawing the page went looking for an account.
       expect(service.state.connectRequests).toBe(0);
     } finally {
       await service.close();
@@ -480,10 +521,11 @@ test.describe('Advanced Settings login gate', () => {
     }
   });
 
-  // Signing out drops this device's credential and nothing else. The switches
-  // are synced, so writing them off would disable the feature on every other
-  // device the account is still signed in on.
-  test('signing out clears the token but leaves the synced switches alone', async ({ context, page, extensionId }) => {
+  // Signing out takes both switches off screen with the token — neither feature
+  // can run without one — but writes neither off. They are synced, so answering
+  // the preference would disable the feature on every other device the account
+  // is still signed in on; signing back in is what restores them here.
+  test('signing out turns both switches off without answering the synced preference', async ({ context, page, extensionId }) => {
     const service = await startMockService();
     try {
       const worker = await connectExtension(context, service.base);
@@ -499,8 +541,10 @@ test.describe('Advanced Settings login gate', () => {
       await expect.poll(async () => worker.evaluate(
         () => chrome.storage.local.get({ comicToken: '' }),
       )).toEqual({ comicToken: '' });
-      await expect(page.locator('#enableComicTranslation')).toBeChecked();
-      await expect(page.locator('#enablePdfTranslation')).toBeChecked();
+      await expect(page.locator('#enableComicTranslation')).not.toBeChecked();
+      await expect(page.locator('#enablePdfTranslation')).not.toBeChecked();
+      await expect(page.locator('#comicTargetLang')).toBeDisabled();
+      await expect(page.locator('#pdfTargetLang')).toBeDisabled();
       await expect.poll(async () => worker.evaluate(
         () => chrome.storage.sync.get({ enableComicTranslation: false, enablePdfTranslation: false }),
       )).toEqual({ enableComicTranslation: true, enablePdfTranslation: true });

--- a/test/e2e/feature-settings.spec.js
+++ b/test/e2e/feature-settings.spec.js
@@ -1,5 +1,5 @@
 const { test, expect } = require('./fixtures');
-const { setExtensionSettings } = require('./helpers');
+const { setExtensionSettings, setExtensionAccount } = require('./helpers');
 
 async function getSetting(context, key) {
   let worker = context.serviceWorkers()[0];
@@ -210,12 +210,16 @@ test('popup toggle updates youtube caption setting', async ({ page, context, ext
 });
 
 /**
- * Requirement of the free model: PDF translation ships ON, and switching it off
- * has to retract every way in — the two popup rows and the two context menu
- * entries — not just grey out the settings card.
+ * Requirement of the free model: PDF translation ships ON for an account, and
+ * switching it off has to retract every way in — the two popup rows and the two
+ * context menu entries — not just grey out the settings card.
  */
 test('the PDF switch is on by default and its entry points follow it', async ({ page, context, extensionId }) => {
   await setExtensionSettings(page, { targetLang: 'en', targetLangSetByUser: true });
+  // "On by default" is a statement about the preference, and the preference
+  // only reaches the screen on a device that has the account the feature runs
+  // on. Signed out it is off no matter what — the test below this one.
+  await setExtensionAccount(page);
 
   const popupUrl = `chrome-extension://${extensionId}/popup/popup.html`;
   await page.goto(popupUrl);
@@ -249,6 +253,76 @@ test('the PDF switch is on by default and its entry points follow it', async ({ 
   await expect(page.locator('#pdfTranslateThis')).toBeHidden();
 
   await worker.evaluate(() => { delete globalThis.__pdfMenuUpdates; });
+});
+
+/**
+ * The rule the two account-backed features are subject to and no other setting
+ * is: a device with no account cannot run either, so neither may show as on.
+ *
+ * The switches sync and the token does not, so this is the state EVERY new
+ * install starts in — PDF ships on, so its preference arrives switched on
+ * before the user has ever signed in. Showing that as an on switch offers a
+ * feature whose every entry point can only answer "sign in".
+ */
+test('signed out, both account features read off however the preference arrived', async ({ page, context, extensionId }) => {
+  await setExtensionSettings(page, {
+    targetLang: 'en',
+    targetLangSetByUser: true,
+    // Exactly what sync delivers from a device that IS signed in.
+    enableComicTranslation: true,
+    enablePdfTranslation: true,
+  });
+  await setExtensionAccount(page, false);
+
+  await page.goto(`chrome-extension://${extensionId}/options/options.html`);
+  await expect(page.locator('#comicSignedOut')).toBeVisible();
+  await expect(page.locator('#enableComicTranslation')).not.toBeChecked();
+  await expect(page.locator('#enablePdfTranslation')).not.toBeChecked();
+  // A switch that reads off must not leave its language select live.
+  await expect(page.locator('#comicTargetLang')).toBeDisabled();
+  await expect(page.locator('#pdfTargetLang')).toBeDisabled();
+
+  // Every other way in is gone too — the switch is not merely cosmetic.
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await expect(page.locator('#comicTranslatePage')).toBeHidden();
+  await expect(page.locator('#comicColorizePage')).toBeHidden();
+  await expect(page.locator('#pdfTranslateLocal')).toBeHidden();
+
+  // And the preference itself is untouched: it belongs to the account, not to
+  // this device. Writing it off here would sync back and disable the feature on
+  // the device that is still signed in.
+  expect(await getSetting(context, 'enableComicTranslation')).toBe(true);
+  expect(await getSetting(context, 'enablePdfTranslation')).toBe(true);
+});
+
+/**
+ * The other half of the same rule: signing in is what makes the preference
+ * count again, without the user having to re-flip anything.
+ */
+test('signing in restores the preference the signed-out device was hiding', async ({ page, context, extensionId }) => {
+  await setExtensionSettings(page, {
+    targetLang: 'en',
+    targetLangSetByUser: true,
+    enableComicTranslation: true,
+    enablePdfTranslation: true,
+  });
+  await setExtensionAccount(page, false);
+
+  await page.goto(`chrome-extension://${extensionId}/options/options.html`);
+  await expect(page.locator('#enableComicTranslation')).not.toBeChecked();
+
+  await setExtensionAccount(page, true);
+  await page.reload();
+
+  await expect(page.locator('#comicSignedIn')).toBeVisible();
+  await expect(page.locator('#enableComicTranslation')).toBeChecked();
+  await expect(page.locator('#enablePdfTranslation')).toBeChecked();
+  await expect(page.locator('#comicTargetLang')).toBeEnabled();
+  await expect(page.locator('#pdfTargetLang')).toBeEnabled();
+
+  await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+  await expect(page.locator('#comicTranslatePage')).toBeVisible();
+  await expect(page.locator('#pdfTranslateLocal')).toBeVisible();
 });
 
 /**

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -183,6 +183,44 @@ async function setExtensionSettings(page, settings) {
 }
 
 /**
+ * Give the extension the account that comic and PDF translation require.
+ *
+ * Comic and PDF translation are gated on a token in chrome.storage.local as
+ * well as on their switches (see shared/account-gate.js), so any test about
+ * either feature being ON has to establish one. The account cache is seeded
+ * alongside the token so nothing reaches the network: getAccount() serves it
+ * for 30 seconds before asking the service.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {boolean} signedIn pass false to put the device back to signed out
+ */
+async function setExtensionAccount(page, signedIn = true) {
+  const context = page.context();
+  let worker = context.serviceWorkers()[0];
+  if (!worker) {
+    worker = await context.waitForEvent('serviceworker');
+  }
+  await worker.evaluate(async (isSignedIn) => {
+    if (!isSignedIn) {
+      await chrome.storage.local.remove(['comicToken', 'comicTokenExpiresAt', 'comicAccountCache']);
+      return;
+    }
+    const quota = { limit: 40, used: 0, remaining: 40, applied: false, resetsAt: '2099-02-01T00:00:00.000Z' };
+    await chrome.storage.local.set({
+      comicToken: 'test-token',
+      comicTokenExpiresAt: Date.now() + 3600_000,
+      comicAccountCache: {
+        fetchedAt: Date.now(),
+        account: {
+          user: { email: 'reader@example.com', name: 'Reader' },
+          freeQuotas: { comic_page: quota, pdf_page: quota },
+        },
+      },
+    });
+  }, signedIn);
+}
+
+/**
  * Send a message to the active tab from the extension service worker
  * @param {import('@playwright/test').Page} page
  * @param {object} message
@@ -213,5 +251,6 @@ module.exports = {
   triggerSelectionHotkey,
   getCurrentTheme,
   setExtensionSettings,
+  setExtensionAccount,
   sendMessageToActiveTab,
 };

--- a/test/unit/account-gate.test.mjs
+++ b/test/unit/account-gate.test.mjs
@@ -1,0 +1,101 @@
+// Guards for shared/account-gate.js — the module that decides whether comic and
+// PDF translation are on, from the switch in sync storage AND the account token
+// in local storage.
+//
+// The rule it enforces is easy to defeat by accident: a new surface reads
+// `enableComicTranslation` straight out of chrome.storage.sync, forgets the
+// account half, and offers a signed-out user a feature whose every entry point
+// can only answer "sign in". That is asserted here rather than eyeballed.
+//
+// Run with: npm run test:unit
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8');
+
+// The module has no `export` (it is also loaded as a classic script by the
+// popup, the options page and the content scripts), so importing it for its
+// side effect publishes globalThis.AccountGate.
+await import('../../shared/account-gate.js');
+const gate = globalThis.AccountGate;
+
+/** Stand in for the storage area the token lives in. */
+function withToken(token) {
+  globalThis.chrome = { storage: { local: { get: async (defaults) => ({ ...defaults, comicToken: token }) } } };
+}
+
+test('both account-backed switches are governed, and nothing else is', () => {
+  assert.deepEqual(gate.ACCOUNT_FEATURE_KEYS, ['enableComicTranslation', 'enablePdfTranslation']);
+});
+
+test('a device with no token cannot have either feature on', async () => {
+  withToken('');
+  const settings = await gate.applyAccountGate({
+    enableComicTranslation: true,
+    enablePdfTranslation: true,
+    showFloatBall: true,
+  });
+  assert.equal(settings.enableComicTranslation, false);
+  assert.equal(settings.enablePdfTranslation, false);
+  // Every other setting is none of this module's business.
+  assert.equal(settings.showFloatBall, true);
+});
+
+test('a device with a token keeps the stored preference exactly', async () => {
+  withToken('a-token');
+  assert.deepEqual(
+    await gate.applyAccountGate({ enableComicTranslation: true, enablePdfTranslation: false }),
+    { enableComicTranslation: true, enablePdfTranslation: false },
+  );
+});
+
+test('a storage failure fails closed', async () => {
+  globalThis.chrome = { storage: { local: { get: async () => { throw new Error('context invalidated'); } } } };
+  assert.equal((await gate.applyAccountGate({ enableComicTranslation: true })).enableComicTranslation, false);
+});
+
+test('both off skips the token read entirely', async () => {
+  let reads = 0;
+  globalThis.chrome = { storage: { local: { get: async () => { reads += 1; return { comicToken: '' }; } } } };
+  await gate.applyAccountGate({ enableComicTranslation: false, enablePdfTranslation: false });
+  assert.equal(reads, 0, 'the common case must not cost a storage read on every settings load');
+});
+
+test('the token key matches the one comic-client.js writes', () => {
+  const client = repoFile('background/comic-client.js');
+  assert.match(client, /token:\s*'comicToken'/,
+    'comic-client.js renamed the token key — shared/account-gate.js reads it by name');
+  assert.equal(gate.TOKEN_KEY, 'comicToken');
+});
+
+// Each of these renders or acts on the two switches, so each has to be able to
+// weigh the account half. A page that reads the keys without loading the module
+// cannot.
+test('every surface that reads the two switches loads the gate', () => {
+  // Matched as script tags, not bare filenames: prose in the markup mentions
+  // popup.js well above the tags themselves.
+  const surfaces = [
+    ['options/options.html', 'options.js'],
+    ['popup/popup.html', 'popup.js'],
+  ];
+  for (const [file, own] of surfaces) {
+    const html = repoFile(file);
+    const tag = (src) => html.indexOf(`<script src="${src}"`);
+    const at = tag('../shared/account-gate.js');
+    assert.ok(at !== -1, `${file} must load shared/account-gate.js`);
+    assert.ok(at < tag(own), `shared/account-gate.js must load before ${own}`);
+  }
+
+  const manifest = JSON.parse(repoFile('manifest.json'));
+  const scripts = manifest.content_scripts.find(entry => entry.js.includes('content/content-bootstrap.js')).js;
+  assert.ok(
+    scripts.indexOf('shared/account-gate.js') !== -1 &&
+    scripts.indexOf('shared/account-gate.js') < scripts.indexOf('content/content-bootstrap.js'),
+    'content scripts must load shared/account-gate.js before content-bootstrap.js reads settings',
+  );
+
+  assert.match(repoFile('background/background.js'), /import '\.\.\/shared\/account-gate\.js'/,
+    'the service worker gates the context menu entries on the account too');
+});


### PR DESCRIPTION
## The bug

With no account signed in, the comic-translation and PDF-translation switches in Settings still read ON, and could still be turned on.

## Root cause

The two switches and the credential they depend on live in different storage areas:

| what | where | scope |
| --- | --- | --- |
| `enableComicTranslation` / `enablePdfTranslation` | `chrome.storage.sync` | per account |
| `comicToken` | `chrome.storage.local` | per device |

Three separate paths therefore left a signed-out device reading ON:

1. `enablePdfTranslation` defaults to `true`, so a fresh install ships PDF on.
2. Signing out cleared the token but deliberately left both switches alone — there was even a test asserting that.
3. Sync pushes the preference down to every new device, while the token never follows.

## Why not just write `false`

Because of (3). A brand-new install syncs the switches down *before* it has ever signed in, so a signed-out device that "corrected" the preference would reach across and turn the feature off on the device that is still signed in.

## The fix

The answer is **derived on every read and never written back**, in a new `shared/account-gate.js`. The stored preference survives untouched; a device with no token simply cannot see it as on, and signing in restores what was already there without the user re-flipping anything.

Every surface that reads either switch now runs it through `AccountGate.applyAccountGate()`: the options page, the popup, the content scripts (including the error fallback, which also defaulted PDF to `true`), and the service worker's context-menu entries. The worker also re-checks the menus when the token itself changes in local storage, so signing out retracts them without a reload.

Two deliberate details:

- The options page tracks sign-in as a **tri-state**, `null` meaning unknown. A failed `/api/billing/me` is not the same as being signed out, so a service outage no longer yanks the switches out from under a user who is genuinely signed in.
- `assertFeatureEnabled()` still judges the raw switch on purpose. The account half is enforced one layer down, where a tokenless create answers `unauthorized` — which every surface turns into a sign-in offer, whereas `feature_disabled` is a dead end.

`CLAUDE.md` gains an "Account-Backed Features" section recording the storage split and the derive-don't-write rule, mirroring the existing `shared/api-compat.js` contract.

## Tests

- `npm run test:unit` — 21/21 pass, including a new `test/unit/account-gate.test.mjs`: the gate fails closed on a storage error, skips the token read when both switches are already off, and every surface actually loads the module.
- `npx playwright test test/e2e/comic-account.spec.js test/e2e/feature-settings.spec.js` — 28/28 pass. New coverage: a synced-on switch stays off without a local account; signing in restores the preference the device was hiding; signing out turns both off while sync still reads `{true, true}`.
- Full `npm test` — 81 passed, 9 skipped, 10 failed. Those 10 (hover-translation ×3, input-translation, two page-translation specs, youtube-caption ×4) are **pre-existing**: verified failing identically on clean `main` with the change stashed. Translation-engine and YouTube-caption tests, unrelated to this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
