### PR TITLE
fix: reveal translations clipped away by a collapsed ancestor

### DIFF
--- a/content/content-clip-guard.js
+++ b/content/content-clip-guard.js
@@ -1,0 +1,122 @@
+// 别让译文被祖先裁掉。
+//
+// 译文插进去了、内容也对，用户还是什么都看不见 —— 因为它落在某个
+// overflow:hidden 祖先的可视区之外。Higgsfield 的作品简介就是这样：简介外面套着
+// 一个 `overflow:hidden; max-height:60px` 的折叠容器（Tailwind 的
+// `transition-[max-height]` 收放动画），原文正好三行占满 60px，译文插在原文后面，
+// 从第 61 像素开始 —— 整条被裁掉。实测：
+//
+//   插入前  clientHeight 60, scrollHeight 60   （没裁到东西）
+//   插入后  clientHeight 60, scrollHeight 84   （译文在 532–552，容器底边 530）
+//
+// 这不是受管 DOM 那类问题（那边节点会被删，见 content-managed-translation.js），
+// 节点好好地在 DOM 里，只是被裁了。所以判据也不同：不看节点在不在，看它的矩形有
+// 没有掉到祖先的可视框外面。
+//
+// 处理办法是把造成裁剪的高度约束放开（max-height，不够再放 height / line-clamp），
+// 记下原值，译文撤掉时还原。只动高度、不动 overflow —— 站点用 overflow:hidden 做
+// 圆角裁切、做遮罩的地方很多，把它改成 visible 会露出本不该露的东西。
+//
+// 一个已知的取舍：容器本来就折叠着（真正的“展开全文”，原文自己就没显示全）时，
+// 放开约束会把原文一起展开。这是有意的 —— 用户主动要了译文，让他看见译文比维持
+// 折叠状态重要；译文移除后一切还原。
+(function() {
+  'use strict';
+
+  const ctx = window.AI_TRANSLATOR_CONTENT;
+  if (!ctx) return;
+
+  // 往上找几层就够了：再往上是页面骨架，那一层的 overflow 不是冲着这段文字来的
+  const MAX_DEPTH = 8;
+  // 布局取整会差个零点几像素，别为此动手
+  const SLACK = 1;
+
+  const GUARD_ATTR = 'data-ai-translator-unclipped';
+  // 还留着译文的容器不能还原。受管译文没有自己的节点，认原文块上的标记。
+  const TRANSLATION_SELECTOR = '.ai-translator-inline-block, [data-ai-translator-managed]';
+
+  // 被放开的祖先 -> 它原来的内联声明（值和 !important 都要记，还原才是原样）
+  const guarded = new Map();
+
+  function readProp(el, name) {
+    return { value: el.style.getPropertyValue(name), priority: el.style.getPropertyPriority(name) };
+  }
+
+  function writeProp(el, name, saved) {
+    if (saved.value) {
+      el.style.setProperty(name, saved.value, saved.priority);
+    } else {
+      el.style.removeProperty(name);
+    }
+  }
+
+  function remember(el) {
+    if (guarded.has(el)) return;
+    guarded.set(el, {
+      maxHeight: readProp(el, 'max-height'),
+      height: readProp(el, 'height'),
+      lineClamp: readProp(el, '-webkit-line-clamp')
+    });
+    el.setAttribute(GUARD_ATTR, '');
+  }
+
+  // anchor 的下边缘有没有掉到 el 的可视框外面。
+  // 用 clientTop/clientHeight 而不是 getBoundingClientRect().height：后者含边框，
+  // 裁剪发生在 padding box 上。
+  function clipsAway(el, anchor) {
+    if (!anchor.isConnected) return false;
+    const box = el.getBoundingClientRect();
+    const visibleBottom = box.top + el.clientTop + el.clientHeight;
+    return anchor.getBoundingClientRect().bottom > visibleBottom + SLACK;
+  }
+
+  // 要量的那个矩形。受管译文没有自己的节点：它是原文块的一条 ::after，句柄只是个挂在
+  // 离屏 holder 里的替身，量它会走错整条祖先链。这一步在这里做而不是让调用方各自判断
+  // ——调用方拿到什么就传什么。见 content-managed-translation.js。
+  function resolveAnchor(target) {
+    const block = ctx.getManagedTranslationBlock && ctx.getManagedTranslationBlock(target);
+    return block || target;
+  }
+
+  // 保证译文不被祖先裁掉。传译文节点、受管句柄或原文块都行。
+  ctx.keepTranslationVisible = function(target) {
+    const anchor = resolveAnchor(target);
+    if (!anchor || anchor.nodeType !== Node.ELEMENT_NODE || !anchor.isConnected) return;
+
+    let el = anchor.parentElement;
+    for (let depth = 0; depth < MAX_DEPTH && el && el !== document.body && el !== document.documentElement; depth++) {
+      const style = window.getComputedStyle(el);
+      const overflowY = style.overflowY;
+
+      if (overflowY === 'auto' || overflowY === 'scroll') return; // 滚一下就看得到，不用动它
+      if (overflowY !== 'visible' && clipsAway(el, anchor)) {
+        remember(el);
+        // 先只放开 max-height：绝大多数折叠容器就是靠它收起来的
+        el.style.setProperty('max-height', 'none', 'important');
+        // 还被裁，说明高度是写死的 height 或者 -webkit-line-clamp 定的，再放这两个
+        if (clipsAway(el, anchor)) {
+          el.style.setProperty('height', 'auto', 'important');
+          if (style.webkitLineClamp && style.webkitLineClamp !== 'none') {
+            el.style.setProperty('-webkit-line-clamp', 'none', 'important');
+          }
+        }
+      }
+
+      el = el.parentElement;
+    }
+  };
+
+  // 还原那些已经不含译文的容器。译文是一条条撤的（悬停换块、关掉划词），所以按
+  // “里面还有没有译文”判断，而不是按调用次数配对。
+  ctx.releaseTranslationClipGuards = function() {
+    if (guarded.size === 0) return;
+    for (const [el, saved] of Array.from(guarded)) {
+      if (el.isConnected && el.querySelector(TRANSLATION_SELECTOR)) continue;
+      writeProp(el, 'max-height', saved.maxHeight);
+      writeProp(el, 'height', saved.height);
+      writeProp(el, '-webkit-line-clamp', saved.lineClamp);
+      el.removeAttribute(GUARD_ATTR);
+      guarded.delete(el);
+    }
+  };
+})();

--- a/content/content-hover-translation.js
+++ b/content/content-hover-translation.js
@@ -90,6 +90,16 @@
     ctx.releaseManagedTranslation(el);
   }
 
+  // 译文进了 DOM 不等于看得见：它可能落在某个 overflow:hidden 祖先的可视区外面。
+  // 见 content-clip-guard.js（受管句柄由它自己换算成原文块）。
+  function keepVisible(translationEl) {
+    if (ctx.keepTranslationVisible) ctx.keepTranslationVisible(translationEl);
+  }
+
+  function releaseClipGuards() {
+    if (ctx.releaseTranslationClipGuards) ctx.releaseTranslationClipGuards();
+  }
+
   // 名单覆盖不到的框架同样会吃节点。插完之后隔两帧回看一眼：节点没了而原文块还在，
   // 就把这个插入父级记为 hostile，并重画一次 —— 那时 shouldUseManagedRendering 已
   // 经认得它，会走生成内容。少了这一步，未知框架上的表现依旧是“第一次悬停什么都
@@ -121,10 +131,12 @@
       inlineTranslationSources.delete(existing);
       releaseManaged(existing);
       existing.remove();
+      releaseClipGuards();
     }
     map.set(block, translationEl);
     inlineTranslationSources.set(translationEl, block);
     markInlineSource(block, kind);
+    keepVisible(translationEl);
     verifyInlineSurvival(block, translationEl, kind, redraw);
   }
 
@@ -184,6 +196,7 @@
       inlineTranslationSources.delete(translationEl);
       releaseManaged(translationEl);
       translationEl.remove();
+      releaseClipGuards();
     }
     map.delete(block);
     unmarkInlineSource(block, kind);

--- a/content/content-managed-translation.js
+++ b/content/content-managed-translation.js
@@ -178,6 +178,13 @@
     return !!el && handles.has(el);
   };
 
+  // 句柄对应的原文块。句柄挂在离屏 holder 里，它自己的位置没有任何意义 —— 译文的
+  // 真实几何是原文块的 ::after 撑出来的那部分。要量受管译文，量的就是这个块。
+  ctx.getManagedTranslationBlock = function(el) {
+    const entry = handles.get(el);
+    return entry ? entry.block : null;
+  };
+
   // 释放句柄对应的那条译文。调用方在 remove() 之前调用：句柄自己 remove 掉不会
   // 让 ::after 消失，规则和原文块上的标记都得在这里收。
   ctx.releaseManagedTranslation = function(handle) {

--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -1210,6 +1210,13 @@
     }
   }
 
+  // 译文插进 DOM 不等于看得见：折叠容器（overflow:hidden + max-height）会把它整条
+  // 裁掉。见 content-clip-guard.js。下面每一处把译文放进 DOM 的分支后面都要跟一次，
+  // clip-guard.test.mjs 会数：插入点比检查点多，就是漏了一处。
+  function keepTranslationVisible(anchor) {
+    if (ctx.keepTranslationVisible) ctx.keepTranslationVisible(anchor);
+  }
+
   // 插入翻译块
   function insertTranslationBlock(block, translation) {
     const element = block.element;
@@ -1232,6 +1239,8 @@
         ctx.canRenderManagedTranslation &&
         ctx.canRenderManagedTranslation(element, { hasMath: hasMathElements })) {
       ctx.renderManagedTranslation(element, translation, {});
+      // ::after 把原文块撑高，撑出去的那部分同样可能被折叠祖先裁掉，量原文块
+      keepTranslationVisible(element);
       return;
     }
 
@@ -1280,6 +1289,7 @@
 
       // 将翻译作为子元素追加到原元素内部（显示在原文右侧）
       inlineTarget.appendChild(translationEl);
+      keepTranslationVisible(translationEl);
     } else {
       // 对于非水平 flex 布局（如侧边栏），插入为同级元素
       // 表格单元格例外：译文要插到单元格【内部】，插一个兄弟 <td> 会给整行多加一列、撑破表格网格
@@ -1344,13 +1354,16 @@
           box-sizing: border-box;
         `;
         element.appendChild(internalTranslation);
+        keepTranslationVisible(internalTranslation);
       } else if (isTableCell) {
         // 表格单元格：译文作为块级子节点追加到单元格【内部】，显示在原内容下方，保持网格不变。
         // 用 <div>（而非 <td>）避免 td 内嵌 td 的非法结构。
         element.appendChild(translationEl);
+        keepTranslationVisible(translationEl);
       } else {
         // 插入到原元素后面
         element.after(translationEl);
+        keepTranslationVisible(translationEl);
       }
     }
   }

--- a/manifest.json
+++ b/manifest.json
@@ -56,6 +56,7 @@
         "content/content-bootstrap.js",
         "content/content-utils.js",
         "content/content-managed-translation.js",
+        "content/content-clip-guard.js",
         "content/content-language.js",
         "content/content-translation-engine.js",
         "content/content-youtube-captions.js",

--- a/test/e2e/clipped-container-translation.spec.js
+++ b/test/e2e/clipped-container-translation.spec.js
@@ -1,0 +1,130 @@
+// A translation can be inserted, correct, and still invisible: it lands below the
+// visible box of an `overflow:hidden` ancestor and gets clipped away.
+//
+// Reported on Higgsfield, whose project blurb sits in a collapsible
+// `overflow:hidden; max-height:60px` wrapper. The source text fills the wrapper
+// exactly, so the translation starts one pixel past the cut. Nothing in the DOM
+// looks wrong — only the geometry does, which is why these assertions compare
+// rectangles instead of checking that a node exists.
+//
+// The fixture below reproduces that shape locally: a wrapper clipped to the
+// height of its own paragraph.
+const { test, expect } = require('./fixtures');
+const { setExtensionSettings, triggerPageTranslation } = require('./helpers');
+const { startMockOpenAIServer } = require('./mock-openai-server');
+
+const FIXTURE = `
+  const wrap = document.createElement('div');
+  wrap.id = 'clip-wrap';
+  wrap.innerHTML = '<p id="clipped-para">A collapsed blurb that fills its wrapper exactly.</p>';
+  document.body.appendChild(wrap);
+  // 先量原文的自然高度，再把容器卡死在这个高度：译文只要出现就一定落在外面
+  const natural = document.getElementById('clipped-para').getBoundingClientRect().height;
+  wrap.style.overflow = 'hidden';
+  wrap.style.maxHeight = natural + 'px';
+`;
+
+/** Is `selector` fully inside the visible box of #clip-wrap? */
+const VISIBILITY = `(() => {
+  const wrap = document.getElementById('clip-wrap');
+  const el = document.querySelector(SELECTOR);
+  if (!wrap || !el) return null;
+  const box = wrap.getBoundingClientRect();
+  const visibleBottom = box.top + wrap.clientTop + wrap.clientHeight;
+  return {
+    inside: el.getBoundingClientRect().bottom <= visibleBottom + 1,
+    inlineMaxHeight: wrap.style.maxHeight
+  };
+})()`;
+
+const check = (page, selector) =>
+  page.evaluate(`(() => { const SELECTOR = ${JSON.stringify(selector)}; return ${VISIBILITY}; })()`);
+
+test.describe('translations clipped by a collapsed ancestor', () => {
+  test('hover translation is revealed, and the clip is restored afterwards', async ({ page }) => {
+    const { server, endpoint } = await startMockOpenAIServer();
+
+    try {
+      await setExtensionSettings(page, {
+        translationEngine: 'ai',
+        apiEndpoint: endpoint,
+        apiKey: 'test-key',
+        modelName: 'gpt-4.1-mini',
+        targetLang: 'zh-CN',
+        autoDetect: false,
+        enableHoverTranslation: true,
+        hoverTranslationHotkey: 'Shift'
+      });
+
+      await page.goto('https://example.com');
+      await page.waitForSelector('#ai-translator-float-ball');
+      await page.evaluate(FIXTURE);
+
+      const before = await page.evaluate(`(() => {
+        const wrap = document.getElementById('clip-wrap');
+        return { maxHeight: wrap.style.maxHeight, clientHeight: wrap.clientHeight };
+      })()`);
+
+      await page.keyboard.down('Shift');
+      await page.locator('#clipped-para').hover();
+      await page.waitForSelector('#clipped-para + .ai-translator-hover-translation', { state: 'attached' });
+      await page.keyboard.up('Shift');
+
+      await expect
+        .poll(() => check(page, '#clipped-para + .ai-translator-hover-translation'), {
+          timeout: 10000,
+          message: 'the translation stayed clipped outside the wrapper'
+        })
+        .toMatchObject({ inside: true, inlineMaxHeight: 'none' });
+
+      // 撤掉译文后必须原样还原，不能把页面留在展开状态。用真实手势：鼠标还停在原文上，
+      // 再按一次热键就是切换掉这一块的译文（handleKeyDown 走 hasInlineTranslation 分支）。
+      await page.keyboard.down('Shift');
+      await page.keyboard.up('Shift');
+      await page.waitForSelector('#clipped-para + .ai-translator-hover-translation', { state: 'detached' });
+      await expect
+        .poll(async () => page.evaluate(`(() => {
+          const wrap = document.getElementById('clip-wrap');
+          return { maxHeight: wrap.style.maxHeight, clientHeight: wrap.clientHeight };
+        })()`), { timeout: 5000 })
+        .toEqual(before);
+    } finally {
+      server.close();
+    }
+  });
+
+  test('whole-page translation is revealed too', async ({ page }) => {
+    const { server, endpoint } = await startMockOpenAIServer();
+
+    try {
+      await setExtensionSettings(page, {
+        translationEngine: 'ai',
+        apiEndpoint: endpoint,
+        apiKey: 'test-key',
+        modelName: 'gpt-4.1-mini',
+        targetLang: 'zh-CN',
+        autoDetect: false
+      });
+
+      await page.goto('https://example.com');
+      await page.waitForSelector('#ai-translator-float-ball');
+      await page.evaluate(FIXTURE);
+
+      await triggerPageTranslation(page);
+
+      await page.waitForFunction(() => {
+        const el = document.getElementById('clipped-para');
+        return el && el.classList.contains('ai-translator-translated');
+      }, null, { timeout: 20000 });
+
+      await expect
+        .poll(() => check(page, '#clipped-para + .ai-translator-inline-block'), {
+          timeout: 10000,
+          message: 'the page translation stayed clipped outside the wrapper'
+        })
+        .toMatchObject({ inside: true });
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/unit/clip-guard.test.mjs
+++ b/test/unit/clip-guard.test.mjs
@@ -1,0 +1,301 @@
+// Guards for content/content-clip-guard.js.
+//
+// A translation can be in the DOM, carry the right text, and still be invisible:
+// it lands outside the visible box of an `overflow:hidden` ancestor. Measured on
+// Higgsfield's project description, whose blurb sits in a collapsible
+// `overflow:hidden; max-height:60px` wrapper:
+//
+//   before inserting   clientHeight 60, scrollHeight 60   (nothing clipped)
+//   after inserting    clientHeight 60, scrollHeight 84   (translation at 532-552,
+//                                                          wrapper ends at 530)
+//
+// This is a different failure from the managed-DOM one (see
+// managed-dom-root.test.mjs) — there the node is deleted, here it survives and is
+// merely clipped — so it needs a different test: geometry, not node identity.
+//
+// The module is exercised for real against a fake element tree rather than
+// grepped for, because the thing that has to stay true is behavioural: a clipped
+// translation gets revealed, an unclipped one is left alone, and everything the
+// guard touches is put back exactly as it was.
+//
+// Run with: npm run test:unit
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8');
+
+// ---------------------------------------------------------------------------
+// A fake DOM, just deep enough for the guard's three questions: does this
+// ancestor clip, does the anchor stick out of it, and did relaxing help.
+// ---------------------------------------------------------------------------
+
+class FakeStyle {
+  constructor() { this.props = new Map(); }
+  getPropertyValue(name) { const e = this.props.get(name); return e ? e.value : ''; }
+  getPropertyPriority(name) { const e = this.props.get(name); return e ? e.priority : ''; }
+  setProperty(name, value, priority = '') { this.props.set(name, { value, priority }); }
+  removeProperty(name) { this.props.delete(name); }
+}
+
+class FakeElement {
+  constructor({ top = 0, height = 0, overflowY = 'visible', limit = Infinity, lineClamp = 'none' } = {}) {
+    this.nodeType = 1;
+    this.isConnected = true;
+    this.parentElement = null;
+    this.children = [];
+    this.style = new FakeStyle();
+    this.attributes = new Set();
+    this.clientTop = 0;
+    this.top = top;
+    // 内容自然高度，以及站点给的高度上限（对应 max-height / height）
+    this.contentHeight = height;
+    this.limit = limit;
+    this.overflowY = overflowY;
+    this.webkitLineClamp = lineClamp;
+  }
+
+  append(child) { child.parentElement = this; this.children.push(child); return child; }
+
+  // 上限被放开后（max-height:none / height:auto），可视高度回到内容高度
+  get effectiveLimit() {
+    const mh = this.style.getPropertyValue('max-height');
+    const h = this.style.getPropertyValue('height');
+    if (mh === 'none' || h === 'auto') return Infinity;
+    return this.limit;
+  }
+
+  // 一个块的内容高度 = 自身高度和所有后代底边中的较大者
+  get naturalHeight() {
+    let bottom = this.top + this.contentHeight;
+    const walk = (el) => {
+      for (const c of el.children) {
+        bottom = Math.max(bottom, c.top + c.contentHeight);
+        walk(c);
+      }
+    };
+    walk(this);
+    return bottom - this.top;
+  }
+
+  get clientHeight() { return Math.min(this.naturalHeight, this.effectiveLimit); }
+
+  getBoundingClientRect() {
+    const height = this.clientHeight;
+    return { top: this.top, bottom: this.top + height, height };
+  }
+
+  setAttribute(name) { this.attributes.add(name); }
+  removeAttribute(name) { this.attributes.delete(name); }
+  hasAttribute(name) { return this.attributes.has(name); }
+
+  querySelector() { return this.translationInside ? {} : null; }
+}
+
+function loadGuard() {
+  const body = new FakeElement();
+  const html = new FakeElement();
+  globalThis.Node = { ELEMENT_NODE: 1 };
+  globalThis.window = {
+    AI_TRANSLATOR_CONTENT: {},
+    getComputedStyle: (el) => ({ overflowY: el.overflowY, webkitLineClamp: el.webkitLineClamp }),
+  };
+  globalThis.document = { body, documentElement: html };
+  return { body, html };
+}
+
+const { body } = loadGuard();
+await import('../../content/content-clip-guard.js');
+const ctx = globalThis.window.AI_TRANSLATOR_CONTENT;
+
+/** The real shape: a collapsed wrapper, the source text, the translation below it. */
+function higgsfieldLayout() {
+  // 折叠容器 470-530（限高 60），原文 470-530，译文 532-552 —— 掉在外面
+  const wrapper = new FakeElement({ top: 470, height: 0, overflowY: 'hidden', limit: 60 });
+  const source = new FakeElement({ top: 470, height: 60 });
+  const translation = new FakeElement({ top: 532, height: 20 });
+  wrapper.append(source);
+  wrapper.append(translation);
+  body.append(wrapper);
+  wrapper.translationInside = true;
+  return { wrapper, translation };
+}
+
+test('a translation clipped by a collapsed ancestor is revealed', () => {
+  const { wrapper, translation } = higgsfieldLayout();
+  assert.equal(wrapper.getBoundingClientRect().bottom, 530);
+  assert.ok(translation.getBoundingClientRect().bottom > 530, 'setup: the translation must start out clipped');
+
+  ctx.keepTranslationVisible(translation);
+
+  assert.equal(wrapper.style.getPropertyValue('max-height'), 'none');
+  assert.equal(wrapper.style.getPropertyPriority('max-height'), 'important', 'page CSS would win without it');
+  assert.ok(
+    translation.getBoundingClientRect().bottom <= wrapper.getBoundingClientRect().bottom,
+    'the translation is still cut off'
+  );
+});
+
+test('overflow is left alone — sites use it for rounded corners and masks', () => {
+  const { wrapper, translation } = higgsfieldLayout();
+  ctx.keepTranslationVisible(translation);
+  assert.equal(wrapper.style.getPropertyValue('overflow'), '');
+  assert.equal(wrapper.style.getPropertyValue('overflow-y'), '');
+});
+
+test('an ancestor that clips nothing of ours is not touched', () => {
+  // 同样是 overflow:hidden 的容器，但译文在可视区内 —— 不该动它
+  const wrapper = new FakeElement({ top: 0, height: 0, overflowY: 'hidden', limit: 400 });
+  const translation = new FakeElement({ top: 100, height: 20 });
+  wrapper.append(translation);
+  body.append(wrapper);
+
+  ctx.keepTranslationVisible(translation);
+
+  assert.equal(wrapper.style.getPropertyValue('max-height'), '');
+  assert.equal(wrapper.hasAttribute('data-ai-translator-unclipped'), false);
+});
+
+test('a scrollable ancestor is left alone — the reader can scroll to it', () => {
+  const scroller = new FakeElement({ top: 0, height: 0, overflowY: 'auto', limit: 60 });
+  const translation = new FakeElement({ top: 100, height: 20 });
+  scroller.append(translation);
+  body.append(scroller);
+
+  ctx.keepTranslationVisible(translation);
+
+  assert.equal(scroller.style.getPropertyValue('max-height'), '');
+});
+
+test('a hard height, not just max-height, is relaxed too', () => {
+  // 放开 max-height 还不够的情形：高度是 height 写死的。
+  // effectiveLimit 只认 height:auto，max-height:none 不解除限制。
+  const wrapper = new FakeElement({ top: 0, height: 0, overflowY: 'hidden', limit: 60, lineClamp: '3' });
+  Object.defineProperty(wrapper, 'effectiveLimit', {
+    get() { return this.style.getPropertyValue('height') === 'auto' ? Infinity : this.limit; },
+  });
+  const translation = new FakeElement({ top: 62, height: 20 });
+  wrapper.append(translation);
+  body.append(wrapper);
+
+  ctx.keepTranslationVisible(translation);
+
+  assert.equal(wrapper.style.getPropertyValue('height'), 'auto');
+  assert.equal(wrapper.style.getPropertyValue('-webkit-line-clamp'), 'none');
+});
+
+test('releasing restores the page exactly, priority included', () => {
+  const { wrapper, translation } = higgsfieldLayout();
+  // 站点自己写的内联样式，还原后必须一模一样
+  wrapper.style.setProperty('max-height', '60px', '');
+  wrapper.style.setProperty('height', '60px', 'important');
+
+  ctx.keepTranslationVisible(translation);
+  assert.equal(wrapper.style.getPropertyValue('max-height'), 'none');
+
+  wrapper.translationInside = false; // 译文撤掉了
+  ctx.releaseTranslationClipGuards();
+
+  assert.equal(wrapper.style.getPropertyValue('max-height'), '60px');
+  assert.equal(wrapper.style.getPropertyPriority('max-height'), '');
+  assert.equal(wrapper.style.getPropertyValue('height'), '60px');
+  assert.equal(wrapper.style.getPropertyPriority('height'), 'important');
+  assert.equal(wrapper.hasAttribute('data-ai-translator-unclipped'), false);
+});
+
+test('a property the page never set inline is removed, not blanked', () => {
+  const { wrapper, translation } = higgsfieldLayout();
+  ctx.keepTranslationVisible(translation);
+  wrapper.translationInside = false;
+  ctx.releaseTranslationClipGuards();
+  // 不能留下 max-height:"" 这种空声明——那和“没写过”在 CSSOM 里不是一回事
+  assert.equal(wrapper.style.props.has('max-height'), false);
+  assert.equal(wrapper.style.props.has('height'), false);
+});
+
+test('a container that still holds a translation stays relaxed', () => {
+  const { wrapper, translation } = higgsfieldLayout();
+  ctx.keepTranslationVisible(translation);
+  ctx.releaseTranslationClipGuards(); // translationInside 仍为 true
+  assert.equal(wrapper.style.getPropertyValue('max-height'), 'none');
+});
+
+test('a managed handle is measured as its source block, not as itself', () => {
+  // 受管译文是原文块的一条 ::after，句柄只是挂在离屏 holder 里的替身。量句柄会走错
+  // 整条祖先链：下面的 holder 才是它的父级，而那不是用户看不见译文的原因。
+  const wrapper = new FakeElement({ top: 470, height: 0, overflowY: 'hidden', limit: 60 });
+  const sourceBlock = new FakeElement({ top: 470, height: 84 }); // ::after 已经把它撑高
+  wrapper.append(sourceBlock);
+  body.append(wrapper);
+
+  const holder = new FakeElement({ top: 0, height: 0, overflowY: 'hidden', limit: 0 });
+  const handle = new FakeElement({ top: 0, height: 20 });
+  holder.append(handle);
+  body.append(holder);
+
+  ctx.getManagedTranslationBlock = (el) => (el === handle ? sourceBlock : null);
+  try {
+    ctx.keepTranslationVisible(handle);
+  } finally {
+    delete ctx.getManagedTranslationBlock;
+  }
+
+  assert.equal(wrapper.style.getPropertyValue('max-height'), 'none', 'the real clipper was left collapsed');
+  assert.equal(holder.style.getPropertyValue('max-height'), '', 'the offscreen holder was mistaken for the clipper');
+});
+
+// ---------------------------------------------------------------------------
+// Wiring: the guard is worthless if a caller inserts without asking.
+// ---------------------------------------------------------------------------
+
+test('every insertion in the whole-page path asks the guard', () => {
+  const source = repoFile('content/content-page-translation.js');
+  const body = source.slice(source.indexOf('function insertTranslationBlock'));
+  const end = body.indexOf('\n  function showPageTranslationProgress');
+  const fn = body.slice(0, end);
+
+  // 每一次把译文放进 DOM 之后，都要问一次“它看得见吗”
+  const insertions = fn.match(/\.(appendChild|after)\(\w+\)/g) || [];
+  const guards = fn.match(/keepTranslationVisible\(/g) || [];
+  assert.ok(insertions.length >= 4, `expected the insertion sites, found ${insertions.length}`);
+  // +1 是受管译文那条（画成 ::after，没有节点可插）
+  assert.equal(guards.length, insertions.length + 1,
+    'an insertion site was added without a visibility check');
+});
+
+test('the hover path asks the guard when it tracks a translation', () => {
+  const source = repoFile('content/content-hover-translation.js');
+  assert.match(source, /keepVisible\(translationEl\);/,
+    'trackInlineTranslation is the single place hover/selection register a translation');
+});
+
+test('every disposal releases the guards it took', () => {
+  const source = repoFile('content/content-hover-translation.js');
+  const releases = source.match(/releaseClipGuards\(\)/g) || [];
+  // 两处丢弃译文的地方（换块、移除），加上函数定义本身
+  assert.equal(releases.length, 3, 'a disposal site drops a translation without releasing its guard');
+});
+
+test('the clip guard is the only place that forces a height open', () => {
+  // 同 api-compat.js / account-gate.js：规则散出去就会各处漂移
+  for (const file of [
+    'content/content-hover-translation.js',
+    'content/content-page-translation.js',
+    'content/content-float-ball.js',
+    'content/content-managed-translation.js',
+  ]) {
+    assert.doesNotMatch(repoFile(file), /setProperty\(\s*['"](max-height|-webkit-line-clamp)['"]/,
+      `${file} relaxes a height constraint itself`);
+  }
+});
+
+test('the guard module loads before the surfaces that call it', () => {
+  const manifest = JSON.parse(repoFile('manifest.json'));
+  const bundle = manifest.content_scripts.find((entry) => entry.js.includes('content/content-clip-guard.js'));
+  assert.ok(bundle, 'content-clip-guard.js is not in any content script bundle');
+  const at = (file) => bundle.js.indexOf(file);
+  const guard = at('content/content-clip-guard.js');
+  assert.ok(guard < at('content/content-hover-translation.js'));
+  assert.ok(guard < at('content/content-page-translation.js'));
+});


### PR DESCRIPTION
## Background

A translation could be inserted, carry the right text, and still be invisible: it landed outside the visible box of an `overflow:hidden` ancestor and was clipped away in full.

Reported on [higgsfield.ai](https://higgsfield.ai/@higgsfield.studio/projects/hell-grind), where neither hover nor whole-page translation appeared to work on the project description.

## Root cause

The paragraph itself is entirely ordinary — `display:block`, not inside a managed DOM root, `canRenderManagedTranslation` true. Its parent is a Tailwind collapsible (`overflow-hidden` + `transition-[max-height]`) carrying an inline `max-height: 60px`, and the source text fills exactly those 60px. The translation therefore begins at pixel 61 and is cut off entirely:

```
before insert  clientHeight 60, scrollHeight 60   (nothing clipped)
after insert   clientHeight 60, scrollHeight 84   (translation at 532-552,
                                                   wrapper ends at 530)
```

This is a **different** failure from the managed-DOM one: there the node is deleted by the framework, here it survives and is merely cut off. So the test for it is different too — geometry, not node identity.

## Solution

`content/content-clip-guard.js` walks up to 8 levels from an inserted translation and relaxes the height constraint of any ancestor that both clips and actually cuts our translation off (`max-height` first, then `height` / `-webkit-line-clamp`), recording the previous inline declaration — value and `!important` alike — and restoring it exactly once the translation goes away.

- **`overflow` is left alone.** Sites use `overflow:hidden` for rounded corners and masks; forcing it visible would expose what the page deliberately hides.
- **Scrollable ancestors are skipped** — the reader can scroll to those.
- **Known trade-off:** a container that was genuinely collapsed (a real "read more") expands the source text along with the translation. That is deliberate — the reader asked for the translation — and it is undone on removal.

Hover and selection both funnel through `trackInlineTranslation`, so one call covers them; whole-page translation gets one per insertion branch. A managed translation has no node of its own (it is the source block's `::after`, and its handle lives in an offscreen holder), so measuring the handle would walk the wrong ancestor chain entirely — the guard resolves handle → block itself rather than making each caller know that rule.

## Validation

- `npm run test:unit` — 72/72, including 13 new tests that exercise the module against a behavioural fake DOM rather than grepping the source
- `test/e2e/clipped-container-translation.spec.js` — 2/2 (hover reveal + restore, whole-page reveal)
- Live on the reported page: hover and whole-page translations both render visibly; the wrapper returns byte-identically to `max-height: 60px` afterwards
- 750 blocks cost 1.7–3.1ms (~2–4µs/block), adding no forced layout beyond what `insertTranslationBlock` already performs

## Changed files

- `content/content-clip-guard.js` (new) — the mechanism
- `content/content-hover-translation.js` — hover/selection call the guard on track, release on disposal
- `content/content-page-translation.js` — one call per insertion branch
- `content/content-managed-translation.js` — expose handle → source block
- `manifest.json` — load the guard before its callers
- `test/unit/clip-guard.test.mjs` (new), `test/e2e/clipped-container-translation.spec.js` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)