### PR TITLE
fix(builtin): give up on a wedged Translator instead of hanging the page

### DIFF
--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -1634,14 +1634,22 @@
 
     const pct = Math.max(0, Math.min(100, Math.round((loaded || 0) * 100)));
     if (pct >= 100) {
-      // 下载完成，把进度条交还给翻译进度，否则它会停在“正在下载 100%”上。
-      textEl.textContent = t('translatingProgress');
-      updatePageTranslationProgress(state.translationProgress.current, state.translationProgress.total || 1);
+      ctx.onBuiltinDownloadEnded();
       return;
     }
     textEl.textContent = t('builtinDownloading');
     percentEl.textContent = `${pct}%`;
     barEl.style.width = `${pct}%`;
+  };
+
+  // 下载这一程结束了——下完了、失败了、或者卡住被放弃了。三种情况后面都轮到翻译
+  // 继续走（内置或回落到 AI），所以进度条必须还回去，否则它会停在“正在下载语言包
+  // 45%”上，而页面其实早就在用另一条路翻译了。
+  ctx.onBuiltinDownloadEnded = function() {
+    const textEl = document.querySelector('#ai-translator-progress .ai-translator-progress-text');
+    if (!textEl) return;
+    textEl.textContent = t('translatingProgress');
+    updatePageTranslationProgress(state.translationProgress.current, state.translationProgress.total || 1);
   };
 
   function hidePageTranslationProgress() {

--- a/content/content-translation-engine.js
+++ b/content/content-translation-engine.js
@@ -86,7 +86,11 @@
     UNSUPPORTED_ENV: 'unsupportedEnv',
     UNSUPPORTED_PAIR: 'unsupportedPair',
     NEEDS_DOWNLOAD: 'needsDownload',
-    CREATE_FAILED: 'createFailed'
+    CREATE_FAILED: 'createFailed',
+    // 内置 API 卡住了（见下面的看门狗）。对用户来说和“暂时用不了”是一回事，
+    // engineErrorMessage 的 default 分支就是它的文案；单独列一档是为了让日志和
+    // 回落决策能把“报错了”和“没反应”分开。
+    TIMED_OUT: 'timedOut'
   };
 
   class EngineUnavailableError extends Error {
@@ -159,6 +163,86 @@
     return pageLang;
   }
 
+  // ==================== 卡死看门狗 ====================
+
+  // Translator API 的三个入口（availability / create / translate）都没有超时：
+  // 出问题时它们不 reject，只是永远不 settle。而下面缓存的是 Promise，整页几十个
+  // 块会一起 await 同一个不会 settle 的 create()——进度条停在 0%、不报错，也永远
+  // 走不到回落 AI 那一步。回落逻辑一直是好的，缺的是有人先认输。
+  //
+  // 所以规则是：进内置 API 的每一次调用都必须有上限。这个边界到 Translator 为止，
+  // 再往外（chrome.i18n.detectLanguage 之类）不在此列。
+  //
+  // 但 create() 不能简单地设一个总时长上限：首次下载语言包是几十 MB，慢网上花几
+  // 分钟属于正常，一刀切只会砍掉一个本来能成的功能。所以下载这条路不看总时长，
+  // 只看“还动不动”——每个 downloadprogress 事件把死线往后推。设置页那个用户手点
+  // 的下载按钮因此不受影响：只要还在下，死线就一直在往后走；而它真卡住时，按钮
+  // 也不会再一直转下去。
+  //
+  // “还没开始”和“下得慢”是两回事，窗口也分两档。实测（headless Chrome，
+  // en→zh，availability 返回 downloadable）：卡住的 create() 一个
+  // downloadprogress 都不发，一个事件都等不到。所以第一个事件之前给的是短窗口
+  // ——真的开始下了，浏览器很快就会报第一次进度；等不到就是根本没动起来。
+  // 一旦有了第一个事件，窗口放宽到一分钟：慢链路上两次进度之间安静一阵是正常的。
+  const AVAILABILITY_TIMEOUT_MS = 15000;
+  const CREATE_TIMEOUT_MS = 20000;
+  const DOWNLOAD_START_MS = 30000;
+  const DOWNLOAD_STALL_MS = 60000;
+  // translate() 是端上推理，不走网络，一段正常一两秒。但整页翻译有 12 路并发压在
+  // 同一个模型上，排队会把单次观察到的耗时放大好几倍，所以这条线要留得很宽：
+  // 它的作用是给“永远不返回”封顶，不是给延迟设指标。
+  const TRANSLATE_TIMEOUT_MS = 120000;
+
+  class TimeoutError extends Error {
+    constructor(what) {
+      super(`builtin translator ${what} timed out`);
+      this.name = 'TimeoutError';
+    }
+  }
+
+  /**
+   * 给一个可能永远不 settle 的 Promise 加一条死线。
+   * bump() 把死线整体往后推，用来表达“只要还在动就继续等”；
+   * 带上 nextMs 则同时换掉之后的窗口（第一次进度之后要放宽，见上）。
+   */
+  function stallWatchdog(ms, what) {
+    let timer = null;
+    let stopped = false;
+    let onStall;
+    const stalled = new Promise((resolve, reject) => {
+      onStall = () => reject(new TimeoutError(what));
+    });
+
+    function bump(nextMs) {
+      if (stopped) return;
+      if (typeof nextMs === 'number') ms = nextMs;
+      clearTimeout(timer);
+      timer = setTimeout(onStall, ms);
+    }
+
+    function stop() {
+      stopped = true;
+      clearTimeout(timer);
+    }
+
+    bump();
+    return {
+      bump,
+      /**
+       * race 会给 call 挂上处理函数，所以输的那一路之后再 reject 也只是被丢掉，
+       * 不会变成 unhandled rejection。call 用函数传进来，是为了让同步抛出的异常
+       * 也落进这条链，而不是绕过看门狗直接炸给调用方。
+       */
+      guard(call) {
+        const promise = new Promise((resolve) => resolve(call()));
+        return Promise.race([promise, stalled]).then(
+          (value) => { stop(); return value; },
+          (error) => { stop(); throw error; }
+        );
+      }
+    };
+  }
+
   // ==================== Translator 实例 ====================
 
   // 缓存的是 Promise 而不是实例：整页翻译会在同一瞬间发起几十个块，
@@ -169,32 +253,77 @@
     return `${src}>${tgt}`;
   }
 
-  async function getTranslator(src, tgt, allowDownload, onProgress) {
+  // 三处都要问可用性（翻译前、预取、设置页探测），走同一个入口，
+  // 免得有一处漏了超时又能一直挂着。
+  function probeAvailability(src, tgt) {
+    return stallWatchdog(AVAILABILITY_TIMEOUT_MS, 'availability').guard(
+      () => self.Translator.availability({ sourceLanguage: src, targetLanguage: tgt })
+    );
+  }
+
+  function getTranslator(src, tgt, allowDownload, onProgress) {
     const key = instanceKey(src, tgt);
     const cached = translators.get(key);
     if (cached) return cached;
 
-    const pending = (async () => {
-      const options = { sourceLanguage: src, targetLanguage: tgt };
-      if (allowDownload) {
-        options.monitor = (monitor) => {
-          monitor.addEventListener('downloadprogress', (event) => {
-            const loaded = typeof event.loaded === 'number' ? event.loaded : 0;
-            const handler = onProgress || ctx.onBuiltinDownloadProgress;
-            if (typeof handler === 'function') handler(loaded, src, tgt);
-          });
-        };
+    // 有下载才有 downloadprogress 可看；语言包已就绪时 create() 只是建个会话，
+    // 是本地操作，给一个固定的短上限就够。
+    const watchdog = stallWatchdog(allowDownload ? DOWNLOAD_START_MS : CREATE_TIMEOUT_MS, 'create');
+    const controller = typeof AbortController === 'function' ? new AbortController() : null;
+
+    const options = { sourceLanguage: src, targetLanguage: tgt };
+    if (controller) options.signal = controller.signal;
+    if (allowDownload) {
+      options.monitor = (monitor) => {
+        monitor.addEventListener('downloadprogress', (event) => {
+          // 有动静了：死线往后推，并且从这里开始用宽窗口。
+          watchdog.bump(DOWNLOAD_STALL_MS);
+          const loaded = typeof event.loaded === 'number' ? event.loaded : 0;
+          const handler = onProgress || ctx.onBuiltinDownloadProgress;
+          if (typeof handler === 'function') handler(loaded, src, tgt);
+        });
+      };
+    }
+
+    const pending = watchdog.guard(() => self.Translator.create(options)).then(
+      (translator) => {
+        if (allowDownload) notifyDownloadEnded();
+        return translator;
+      },
+      (error) => {
+        // 失败不留缓存，否则整页翻译会一直复用同一个坏 Promise，
+        // 用户改完设置重试也还是同一个错误。
+        translators.delete(key);
+        // 卡住的下载不会自己好，别让浏览器还挂着它。
+        if (error instanceof TimeoutError && controller) {
+          try { controller.abort(error); } catch (abortError) { /* 已经结束了 */ }
+        }
+        if (allowDownload) notifyDownloadEnded();
+        throw error;
       }
-      return await self.Translator.create(options);
-    })().catch((error) => {
-      // 失败不留缓存，否则整页翻译会一直复用同一个坏 Promise，
-      // 用户改完设置重试也还是同一个错误。
-      translators.delete(key);
-      throw error;
-    });
+    );
 
     translators.set(key, pending);
     return pending;
+  }
+
+  // 下载这一程结束了（下完、失败、或者卡住被放弃）。进度条上这时可能正写着
+  // “正在下载语言包 30%”，回落到 AI 之后那行字会一直留在那儿骗人，所以要把
+  // 进度条交还给翻译进度。设置页有自己的状态行，不挂这个钩子。
+  function notifyDownloadEnded() {
+    if (typeof ctx.onBuiltinDownloadEnded !== 'function') return;
+    try { ctx.onBuiltinDownloadEnded(); } catch (error) { /* 页面已经走了 */ }
+  }
+
+  // 卡住的会话不会自己缓过来，留在缓存里只会让后面每一段再等一次超时。
+  function dropTranslator(src, tgt) {
+    const key = instanceKey(src, tgt);
+    const pending = translators.get(key);
+    if (!pending) return;
+    translators.delete(key);
+    pending.then((translator) => {
+      try { translator.destroy(); } catch (error) { /* 已销毁或页面正在卸载 */ }
+    }, () => {});
   }
 
   function destroyAll() {
@@ -264,11 +393,15 @@
     return chunks;
   }
 
+  function translateOnce(translator, text) {
+    return stallWatchdog(TRANSLATE_TIMEOUT_MS, 'translate').guard(() => translator.translate(text));
+  }
+
   async function runTranslate(translator, text) {
     // 先整段送：NMT 同样吃句子边界和上下文，切得越碎译文越差，
     // 所以只有真的撞到配额上限才退化成分段。
     try {
-      return await translator.translate(text);
+      return await translateOnce(translator, text);
     } catch (error) {
       if (!isQuotaError(error)) throw error;
     }
@@ -276,7 +409,7 @@
     const chunks = splitForQuota(text);
     const parts = [];
     for (const chunk of chunks) {
-      parts.push(await translator.translate(chunk));
+      parts.push(await translateOnce(translator, chunk));
     }
     return parts.join('');
   }
@@ -311,8 +444,11 @@
     if (!translators.has(instanceKey(src, tgt))) {
       let status;
       try {
-        status = await self.Translator.availability({ sourceLanguage: src, targetLanguage: tgt });
+        status = await probeAvailability(src, tgt);
       } catch (error) {
+        // 问都问不出来，那不是这个语言对的问题：判成 UNSUPPORTED_PAIR 的话，
+        // 批量里每一段都会再问一次、再等一次超时。
+        if (error instanceof TimeoutError) throw new EngineUnavailableError(ENGINE_REASONS.TIMED_OUT);
         throw new EngineUnavailableError(ENGINE_REASONS.UNSUPPORTED_PAIR);
       }
       if (status === 'unavailable') {
@@ -340,10 +476,24 @@
       if (isActivationError(error)) {
         throw new EngineUnavailableError(ENGINE_REASONS.NEEDS_DOWNLOAD);
       }
+      if (error instanceof TimeoutError) {
+        throw new EngineUnavailableError(ENGINE_REASONS.TIMED_OUT);
+      }
       throw new EngineUnavailableError(ENGINE_REASONS.CREATE_FAILED);
     }
 
-    const translated = await runTranslate(translator, source);
+    let translated;
+    try {
+      translated = await runTranslate(translator, source);
+    } catch (error) {
+      // 会话卡住是整条链路的事，不是这一段的事：扔掉它，让整批回落 AI，
+      // 否则后面每一段都会在同一个坏会话上再耗一次超时。
+      if (error instanceof TimeoutError) {
+        dropTranslator(src, tgt);
+        throw new EngineUnavailableError(ENGINE_REASONS.TIMED_OUT);
+      }
+      throw error;
+    }
     if (typeof translated !== 'string' || !translated.trim()) {
       throw new Error('builtin translator returned empty result');
     }
@@ -527,7 +677,7 @@
       src = toApiLang(await getPageSourceLang());
       if (!src || !SUPPORTED_LANGS.has(src) || src === tgt) return;
       // downloadable 才需要预取；available 已就绪，downloading 说明别处已经在下了。
-      const status = await self.Translator.availability({ sourceLanguage: src, targetLanguage: tgt });
+      const status = await probeAvailability(src, tgt);
       if (status !== 'downloadable') return;
     } catch (error) {
       return;
@@ -568,7 +718,7 @@
       if (src === tgt) return 'available';
       if (!SUPPORTED_LANGS.has(src) || !SUPPORTED_LANGS.has(tgt)) return 'unavailable';
       try {
-        return await self.Translator.availability({ sourceLanguage: src, targetLanguage: tgt });
+        return await probeAvailability(src, tgt);
       } catch (error) {
         return 'unavailable';
       }
@@ -589,10 +739,15 @@
       }
       if (src === tgt) return 'available';
       try {
+        // 这条路是设置页那颗按钮，下载可以很久，但同样不能无限期地转下去：
+        // 看门狗只在下载停住不动时才收网，正常往下走的下载它一次都不会碰。
         await getTranslator(src, tgt, true, onProgress);
       } catch (error) {
         if (isActivationError(error)) {
           throw new EngineUnavailableError(ENGINE_REASONS.NEEDS_DOWNLOAD);
+        }
+        if (error instanceof TimeoutError) {
+          throw new EngineUnavailableError(ENGINE_REASONS.TIMED_OUT);
         }
         throw new EngineUnavailableError(ENGINE_REASONS.CREATE_FAILED);
       }

--- a/test/unit/builtin-translator-stall.test.mjs
+++ b/test/unit/builtin-translator-stall.test.mjs
@@ -1,0 +1,429 @@
+// Guards for the stall watchdog in content/content-translation-engine.js.
+//
+// The Translator API's three entry points — availability(), create() and
+// translate() — have no timeout. When one of them wedges (a language-pack
+// download that hangs, a session that never answers) the promise does not
+// reject, it simply never settles. `translators` caches the *promise*, so every
+// block of a whole-page translation ends up awaiting the same dead promise:
+// `ctx.requestTranslation` never returns, the progress bar sits at
+// `正在翻译... 0%` forever, and no error is ever shown. The fallback to the AI
+// path below it was always correct — nothing ever gave up long enough to reach
+// it.
+//
+// The fix is a watchdog whose deadline can be pushed back, because the two
+// failure modes it has to tell apart look identical from the outside:
+//
+//   a 40 MB language pack crawling in over a slow link  -> must NOT be killed
+//   a download that stopped moving an hour ago          -> must be killed
+//
+// A wall-clock cap on create() cannot separate those; "no downloadprogress for
+// a full minute" can. That is also why the options page's deliberate,
+// user-initiated download button survives — see the last test.
+//
+// Run with: npm run test:unit
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8');
+
+// ==================== the faked browser ====================
+
+// Enough of a page for the engine's IIFE to install itself and run. Everything
+// interesting is swapped per test through `stubCreate` / `self.Translator`.
+const ENGLISH = 'The quick brown fox jumps over the lazy dog, again and again. ';
+
+let apiKey = 'sk-test';
+let storageListener = () => {};
+const sentToAI = [];
+
+globalThis.self = {
+  isSecureContext: true,
+  Translator: {
+    availability: async () => 'available',
+    create: async () => fakeTranslator(),
+  },
+};
+// Node ships a read-only `navigator`, and the engine reads userActivation off
+// it to decide whether a download may start.
+Object.defineProperty(globalThis, 'navigator', {
+  value: { userActivation: { isActive: true } },
+  configurable: true,
+  writable: true,
+});
+globalThis.window = {
+  AI_TRANSLATOR_CONTENT: {},
+  addEventListener() {},
+  removeEventListener() {},
+};
+globalThis.window.top = globalThis.window;
+globalThis.document = { body: { innerText: ENGLISH.repeat(20) } };
+globalThis.chrome = {
+  i18n: {
+    detectLanguage: async () => ({ isReliable: true, languages: [{ language: 'en', percentage: 99 }] }),
+  },
+  storage: {
+    sync: { get: async () => ({ apiKey }) },
+    onChanged: { addListener: (fn) => { storageListener = fn; } },
+  },
+  runtime: {
+    // Stands in for the AI path: the whole point of the fix is that requests
+    // reach it instead of disappearing into a stuck built-in translator.
+    sendMessage: async (message) => {
+      sentToAI.push(message);
+      if (Array.isArray(message.texts)) return { translations: message.texts.map((x) => `AI:${x}`) };
+      return { translation: `AI:${message.text}`, phonetic: '', isWord: false };
+    },
+  },
+};
+
+// The engine logs every fallback; that is correct behaviour but it drowns the
+// test output, so keep the console quiet and let assertions do the talking.
+console.info = () => {};
+console.warn = () => {};
+
+await import('../../content/content-translation-engine.js');
+const ctx = globalThis.window.AI_TRANSLATOR_CONTENT;
+
+// ==================== helpers ====================
+
+function fakeTranslator(overrides = {}) {
+  return {
+    translate: async (text) => `builtin:${text}`,
+    destroy() {},
+    ...overrides,
+  };
+}
+
+/**
+ * Replace `Translator.create` and record every call. `impl(call)` decides what
+ * the returned promise does; `call.emit(loaded)` fires a `downloadprogress`
+ * event at whatever listener the engine registered on the monitor.
+ */
+function stubCreate(impl) {
+  const calls = [];
+  self.Translator.create = (options) => {
+    const listeners = [];
+    if (typeof options.monitor === 'function') {
+      options.monitor({
+        addEventListener: (type, fn) => { if (type === 'downloadprogress') listeners.push(fn); },
+      });
+    }
+    const call = {
+      options,
+      emit: (loaded) => listeners.forEach((fn) => fn({ loaded })),
+    };
+    calls.push(call);
+    return impl(call);
+  };
+  return calls;
+}
+
+// setImmediate is deliberately left unmocked, so this drains the microtask
+// queue (every await in the engine's own path) without advancing the clock.
+const drain = () => new Promise((resolve) => setImmediate(resolve));
+
+async function waitFor(predicate, label) {
+  for (let i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await drain();
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+async function isPending(promise) {
+  const marker = Symbol('pending');
+  const settled = promise.then(() => 'settled', () => 'settled');
+  return (await Promise.race([settled, drain().then(() => marker)])) === marker;
+}
+
+function translateRequest(targetLang, extra = {}) {
+  return ctx.requestTranslation({ type: 'TRANSLATE', text: ENGLISH, targetLang, ...extra });
+}
+
+const AI_RESULT = { translation: `AI:${ENGLISH}`, phonetic: '', isWord: false };
+
+// ==================== the core failure ====================
+
+test('a create() that never settles falls back to the AI path', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  self.Translator.availability = async () => 'available';
+  const calls = stubCreate(() => new Promise(() => {}));
+
+  const pending = translateRequest('ja');
+  await waitFor(() => calls.length === 1, 'create() to be called');
+
+  // The language pack is already downloaded here, so create() is a local
+  // operation: no progress events exist to wait on, and a short cap applies.
+  t.mock.timers.tick(19_000);
+  assert.equal(await isPending(pending), true, 'gave up before the create budget was spent');
+
+  t.mock.timers.tick(2_000);
+  assert.deepEqual(await pending, AI_RESULT, 'never fell back to the AI path');
+});
+
+test('a whole-page batch gives up once, not once per block', async (t) => {
+  // The reported symptom: "4 blocks, 4 batches", zero requests reaching the API
+  // server, 0% forever. Every block awaits the same cached create() promise, so
+  // the batch must abandon the built-in engine as a whole — waiting out one
+  // timeout per block would just move the hang.
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  self.Translator.availability = async () => 'available';
+  const calls = stubCreate(() => new Promise(() => {}));
+  const texts = ['First block of text.', 'Second block.', 'Third block.', 'Fourth block.'];
+
+  const pending = ctx.requestTranslation({
+    type: 'TRANSLATE_BATCH_FAST', texts, targetLang: 'ru', allowDownload: true,
+  });
+  await waitFor(() => calls.length === 1, 'create() to be called');
+  t.mock.timers.tick(21_000);
+
+  assert.deepEqual(await pending, { translations: texts.map((x) => `AI:${x}`) });
+  assert.equal(calls.length, 1, 'each block waited out its own create() timeout');
+  assert.equal(sentToAI.at(-1).type, 'TRANSLATE_BATCH_FAST', 'the batch did not reach the AI path intact');
+});
+
+// ==================== slow vs. stuck ====================
+
+test('a download that keeps moving is never killed; silence is', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  self.Translator.availability = async () => 'downloadable';
+  const calls = stubCreate(() => new Promise(() => {}));
+
+  const pending = translateRequest('ko');
+  await waitFor(() => calls.length === 1, 'create() to be called');
+
+  // The first event is the one that says the download exists at all; after it
+  // the window widens, because a slow link does go quiet between chunks.
+  t.mock.timers.tick(29_000);
+  calls[0].emit(0.02);
+  await drain();
+
+  // Ten minutes of genuinely slow download. Any wall-clock cap short enough to
+  // rescue the 0% hang would have killed this one; a stall deadline does not.
+  for (let step = 1; step <= 10; step++) {
+    t.mock.timers.tick(59_000);
+    calls[0].emit(step / 20);
+    await drain();
+  }
+  assert.equal(await isPending(pending), true, 'a download that was still moving got killed');
+
+  // Now it stops. One minute of complete silence is the giving-up point.
+  t.mock.timers.tick(59_000);
+  assert.equal(await isPending(pending), true, 'gave up before the stall window was spent');
+  t.mock.timers.tick(2_000);
+  assert.deepEqual(await pending, AI_RESULT, 'a stalled download never fell back');
+});
+
+test('a download that never starts is given up on without waiting out a stall window', async (t) => {
+  // Measured in the very browser the e2e suite drives (headless Chrome,
+  // en->zh): availability() answers "downloadable" in a millisecond and then
+  // create() hangs having never fired a single downloadprogress event. Nothing
+  // is moving, so there is nothing to be patient about — the short window
+  // before the first sign of life is what makes this case recover quickly.
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  self.Translator.availability = async () => 'downloadable';
+  const calls = stubCreate(() => new Promise(() => {}));
+
+  const pending = translateRequest('hu');
+  await waitFor(() => calls.length === 1, 'create() to be called');
+
+  t.mock.timers.tick(29_000);
+  assert.equal(await isPending(pending), true, 'gave up before the start window was spent');
+  t.mock.timers.tick(2_000);
+  assert.deepEqual(await pending, AI_RESULT, 'a download that never began still hung the page');
+});
+
+test('a stalled create is aborted, so the browser stops waiting on it too', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  self.Translator.availability = async () => 'available';
+  const calls = stubCreate(() => new Promise(() => {}));
+
+  const pending = translateRequest('fi');
+  await waitFor(() => calls.length === 1, 'create() to be called');
+  assert.equal(calls[0].options.signal.aborted, false);
+
+  t.mock.timers.tick(21_000);
+  await pending;
+  assert.equal(calls[0].options.signal.aborted, true, 'a dead download was left running');
+});
+
+test('a timed-out create is not cached, so the next attempt really retries', async (t) => {
+  // Caching the promise is what turned one stuck create() into a stuck page.
+  // The flip side is that a timed-out entry must not poison the retry.
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  self.Translator.availability = async () => 'available';
+  const calls = stubCreate(() => new Promise(() => {}));
+
+  const first = translateRequest('fr');
+  await waitFor(() => calls.length === 1, 'the first create()');
+  t.mock.timers.tick(21_000);
+  await first;
+
+  self.Translator.create = async () => fakeTranslator();
+  assert.deepEqual(await translateRequest('fr'), {
+    translation: `builtin:${ENGLISH}`, phonetic: '', isWord: false,
+  });
+});
+
+// ==================== the other two entry points ====================
+
+test('an availability() that never answers is an engine failure, not a bad pair', async (t) => {
+  // Reporting this as UNSUPPORTED_PAIR would make a batch treat it as one
+  // block's problem and ask again for the next block — one timeout per block.
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let asked = 0;
+  self.Translator.availability = () => { asked += 1; return new Promise(() => {}); };
+
+  const texts = ['First block.', 'Second block.', 'Third block.'];
+  const pending = ctx.requestTranslation({
+    type: 'TRANSLATE_BATCH_FAST', texts, targetLang: 'sv', allowDownload: true,
+  });
+  await waitFor(() => asked === 1, 'availability() to be called');
+  t.mock.timers.tick(16_000);
+
+  assert.deepEqual(await pending, { translations: texts.map((x) => `AI:${x}`) });
+  assert.equal(asked, 1, 'every block asked again and waited out its own timeout');
+});
+
+test('a translate() that never returns drops the wedged session and falls back', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  self.Translator.availability = async () => 'available';
+  let destroyed = 0;
+  let translateCalls = 0;
+  self.Translator.create = async () => fakeTranslator({
+    translate: () => { translateCalls += 1; return new Promise(() => {}); },
+    destroy: () => { destroyed += 1; },
+  });
+
+  const pending = translateRequest('pl');
+  await waitFor(() => translateCalls === 1, 'translate() to be called');
+  t.mock.timers.tick(121_000);
+
+  assert.deepEqual(await pending, AI_RESULT);
+  assert.equal(destroyed, 1, 'the wedged session was left in the cache for the next block to hit');
+
+  // And the session really is gone: the next attempt builds a fresh one.
+  self.Translator.create = async () => fakeTranslator();
+  assert.deepEqual(await translateRequest('pl'), {
+    translation: `builtin:${ENGLISH}`, phonetic: '', isWord: false,
+  });
+});
+
+// ==================== what the user is told ====================
+
+test('with no API key there is nothing to fall back to, so the reason is shown', async (t) => {
+  // With an API key the fallback is silent and the page just gets translated.
+  // Without one there is no fallback, and a stall must surface as a message
+  // rather than as a progress bar that never moves. ctx.t is absent here, so
+  // the i18n key itself comes back.
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  storageListener({ apiKey: { newValue: '' } }, 'sync');
+  self.Translator.availability = async () => 'available';
+  const calls = stubCreate(() => new Promise(() => {}));
+
+  const pending = translateRequest('da');
+  await waitFor(() => calls.length === 1, 'create() to be called');
+  t.mock.timers.tick(21_000);
+
+  assert.deepEqual(await pending, { error: 'builtinUnavailable' });
+  storageListener({ apiKey: { newValue: 'sk-test' } }, 'sync');
+});
+
+test('the progress bar is handed back when the download ends, however it ends', async (t) => {
+  // Whole-page translation borrows the progress bar to show the download
+  // percentage. If a stalled download were abandoned without saying so, the bar
+  // would keep reading "downloading language pack, 30%" while the AI path
+  // quietly translated the page behind it.
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  self.Translator.availability = async () => 'downloadable';
+  const calls = stubCreate(() => new Promise(() => {}));
+  let handedBack = 0;
+  ctx.onBuiltinDownloadEnded = () => { handedBack += 1; };
+  t.after(() => { delete ctx.onBuiltinDownloadEnded; });
+
+  const pending = translateRequest('nl');
+  await waitFor(() => calls.length === 1, 'create() to be called');
+  calls[0].emit(0.3);
+  await drain();
+  assert.equal(handedBack, 0, 'handed the bar back while the download was still running');
+
+  t.mock.timers.tick(61_000);
+  await pending;
+  assert.equal(handedBack, 1, 'a stalled download left the bar reading "downloading"');
+});
+
+// ==================== the deliberate download must survive ====================
+
+test("the options page's download button still survives a long, moving download", async (t) => {
+  // ensureDownloaded is the one place a multi-minute wait is the *feature*:
+  // a real user gesture, a visible progress bar, a 40 MB pack. Ten minutes of
+  // download at one progress event every half minute must go through.
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let finishCreate;
+  const calls = stubCreate(() => new Promise((resolve) => { finishCreate = resolve; }));
+  const seen = [];
+
+  const done = ctx.builtinTranslator.ensureDownloaded('en', 'it', (loaded) => seen.push(loaded));
+  await waitFor(() => calls.length === 1, 'create() to be called');
+
+  for (let step = 1; step <= 20; step++) {
+    calls[0].emit(step / 20);
+    await drain();
+    t.mock.timers.tick(30_000);
+  }
+  finishCreate(fakeTranslator());
+
+  assert.equal(await done, 'available');
+  assert.equal(seen.length, 20, 'the progress bar stopped being fed');
+});
+
+test('a download button that really is stuck stops instead of spinning forever', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const calls = stubCreate(() => new Promise(() => {}));
+
+  const done = ctx.builtinTranslator.ensureDownloaded('en', 'tr');
+  await waitFor(() => calls.length === 1, 'create() to be called');
+  t.mock.timers.tick(29_000);
+  assert.equal(await isPending(done), true, 'gave up before the start window was spent');
+  t.mock.timers.tick(2_000);
+
+  await assert.rejects(done, (error) => {
+    assert.equal(error.name, 'EngineUnavailableError');
+    assert.equal(error.reason, 'timedOut');
+    return true;
+  });
+});
+
+// ==================== structural guards ====================
+
+test('every call into the Translator API goes through the watchdog', async () => {
+  // One call site each: availability() behind probeAvailability, create()
+  // behind getTranslator. A second, unwrapped call site is exactly how this bug
+  // comes back — it would hang with no timeout and no way to fall back.
+  const src = repoFile('content/content-translation-engine.js');
+  assert.equal((src.match(/self\.Translator\.availability\(/g) || []).length, 1);
+  assert.equal((src.match(/self\.Translator\.create\(/g) || []).length, 1);
+  assert.match(src, /function stallWatchdog\(/);
+
+  for (const file of [
+    'content/content-page-translation.js',
+    'content/content-hover-translation.js',
+    'content/content-popup.js',
+    'options/options.js',
+  ]) {
+    assert.doesNotMatch(
+      repoFile(file),
+      /Translator\.(create|availability|translate)\(/,
+      `${file} reaches into the Translator API directly, bypassing the watchdog`,
+    );
+  }
+});
+
+test('the page-translation surface answers the download-ended hook', () => {
+  // The engine calls ctx.onBuiltinDownloadEnded whenever a download-bearing
+  // create() ends. Without a listener the progress bar keeps its stale
+  // "downloading language pack" label for the rest of the page translation.
+  assert.match(repoFile('content/content-page-translation.js'), /ctx\.onBuiltinDownloadEnded = function/);
+});


### PR DESCRIPTION
## Background
- This PR packages the current branch changes for review.
- It groups the current branch updates into one reviewable change.

## Solution
- fix(builtin): give up on a wedged Translator instead of hanging the page

## Affected Files
- `content/content-page-translation.js`
- `content/content-translation-engine.js`
- `test/unit/builtin-translator-stall.test.mjs`