### PR TITLE
fix(speech): speak in a tag some installed voice actually answers to

### DIFF
--- a/content/content-speech.js
+++ b/content/content-speech.js
@@ -17,6 +17,11 @@
   // is capped rather than risking a silent cut-off mid-sentence.
   const MAX_SPEAK_CHARS = 1000;
 
+  // Which language to speak in, and which tag an installed voice will answer
+  // to. Both are pure and both are subtle, so they live in shared/ where the
+  // unit suite can drive them against a fixed voice list.
+  const SpeechLang = globalThis.SpeechLang;
+
   // The glyph every speaker button carries. It lives here so the four buttons
   // cannot end up drawn from two slightly different SVGs.
   const SPEAKER_ICON = `
@@ -53,6 +58,25 @@
         resolve('');
       }
     });
+  }
+
+  // getVoices() is empty until the engine has enumerated; Chrome announces the
+  // real list with `voiceschanged`. Resolving against an empty list would fall
+  // through to the raw tag and land back on the default voice, which is the
+  // whole bug, so the first utterance waits for the list.
+  let voicesReady = null;
+  function whenVoicesReady() {
+    if (!voicesReady) {
+      voicesReady = new Promise((resolve) => {
+        if (window.speechSynthesis.getVoices().length) return resolve();
+        const timer = setTimeout(resolve, 1000);
+        window.speechSynthesis.addEventListener('voiceschanged', () => {
+          clearTimeout(timer);
+          resolve();
+        }, { once: true });
+      });
+    }
+    return voicesReady;
   }
 
   function applyButtonState(button, speaking) {
@@ -97,11 +121,13 @@
     if (!trimmed || isStopClick) return false;
 
     const token = ++requestToken;
-    const resolvedLang = lang || await detectLang(trimmed);
+    const spokenLang = await SpeechLang.resolveSpokenLang(trimmed, lang, () => detectLang(trimmed));
+    await whenVoicesReady();
     if (token !== requestToken) return false;
 
     const utterance = new SpeechSynthesisUtterance(trimmed);
-    if (resolvedLang) utterance.lang = resolvedLang;
+    const voiceLang = SpeechLang.resolveSpeechLang(spokenLang, window.speechSynthesis.getVoices());
+    if (voiceLang) utterance.lang = voiceLang;
 
     const finish = () => {
       if (token !== requestToken) return;

--- a/manifest.json
+++ b/manifest.json
@@ -54,6 +54,7 @@
         "i18n/messages.js",
         "shared/account-gate.js",
         "shared/caption-core.js",
+        "shared/speech-lang.js",
         "content/content-bootstrap.js",
         "content/content-utils.js",
         "content/content-managed-translation.js",

--- a/shared/speech-lang.js
+++ b/shared/speech-lang.js
@@ -1,0 +1,128 @@
+// AI Translator — choosing the language a read-aloud button speaks in.
+//
+// Two questions, both easy to get wrong, both pure, so they live here where
+// `npm run test:unit` can exercise them against a synthetic voice list rather
+// than against whichever voices the machine running the tests happens to have.
+//
+//   1. What language is this text actually in?   resolveSpokenLang()
+//   2. What tag will an installed voice answer to? resolveSpeechLang()
+//
+// Question 2 is the one that made every non-Chinese target unintelligible.
+// Chrome matches `utterance.lang` against the installed voices, and when
+// nothing matches it does NOT fall back to a near neighbour — it uses the
+// system default voice. No installed voice carries a bare language tag; every
+// one of the 180 voices macOS ships is region-qualified (`en-US`, `ja-JP`,
+// `fr-FR`). Eight of our ten targets are bare, and so are the ISO-639 codes
+// chrome.i18n.detectLanguage returns. So the common case was the broken one:
+// choosing English on a Chinese-locale Mac set `lang = 'en'`, matched nothing,
+// and read the English out with 婷婷, the system default.
+//
+// Loaded as a classic script by the content scripts, so it publishes onto the
+// global object rather than using `export`.
+(function(root) {
+  'use strict';
+
+  // Widening a bare code needs a region, and the region is a real choice: to a
+  // listener pt-BR and pt-PT are not interchangeable. Every language the
+  // pickers offer needs an entry here, which test/unit/content-speech.test.mjs
+  // checks against content/content-bootstrap.js so the two cannot drift.
+  const SPEECH_REGION = {
+    zh: 'zh-CN',
+    en: 'en-US',
+    ja: 'ja-JP',
+    ko: 'ko-KR',
+    fr: 'fr-FR',
+    de: 'de-DE',
+    es: 'es-ES',
+    pt: 'pt-BR',
+    ru: 'ru-RU',
+  };
+
+  // The scripts our languages use that Latin never borrows wholesale. Japanese
+  // is tested before Chinese: Japanese mixes kanji into kana, so Han alone is
+  // Chinese but Han beside kana is not.
+  const CJK_SCRIPT = {
+    ja: /[぀-ヿ]/,                  // hiragana + katakana
+    ko: /[가-힯ᄀ-ᇿ]/,     // hangul syllables + jamo
+    zh: /[一-鿿]/,                  // han
+  };
+
+  const baseOf = (tag) => String(tag || '').split(/[-_]/)[0].toLowerCase();
+
+  /** The language a piece of text is in when its script alone settles it. */
+  function scriptOf(text) {
+    const value = String(text || '');
+    for (const lang of Object.keys(CJK_SCRIPT)) {
+      if (CJK_SCRIPT[lang].test(value)) return lang;
+    }
+    return '';
+  }
+
+  /**
+   * Widen a language tag until some installed voice answers to it.
+   *
+   * Only the tag is ever set, never `utterance.voice`: once the tag matches,
+   * the engine picks that language's preferred voice. Choosing one ourselves
+   * would mean ranking the 41 English voices macOS installs with no signal for
+   * which are ordinary and which are novelties — the first alphabetically is
+   * Albert, and "Bad News" and "Bells" are in there too.
+   *
+   * @param {string} lang
+   * @param {Array<{lang: string}>} voices speechSynthesis.getVoices()
+   * @returns {string} a tag to put on the utterance, or '' to leave it unset
+   */
+  function resolveSpeechLang(lang, voices) {
+    if (!lang) return '';
+    const tag = String(lang).replace('_', '-');
+    const list = Array.isArray(voices) ? voices : [];
+    // Nothing to check against: hand back the tag rather than guess a region
+    // the machine may not have.
+    if (!list.length) return tag;
+
+    const tagOf = (voice) => String(voice?.lang || '').replace('_', '-');
+    const has = (candidate) => list.some((voice) => tagOf(voice).toLowerCase() === candidate.toLowerCase());
+    if (has(tag)) return tag;
+
+    const preferred = SPEECH_REGION[baseOf(tag)];
+    if (preferred && has(preferred)) return preferred;
+
+    // A language we do not translate into can still turn up as a detected
+    // source language. Whatever region of it is installed beats falling back
+    // to the system default voice.
+    const installed = list.find((voice) => baseOf(tagOf(voice)) === baseOf(tag));
+    return installed ? tagOf(installed) : tag;
+  }
+
+  /**
+   * Which language `text` should actually be spoken in.
+   *
+   * `declared` is what the caller asked the translator for, not what came
+   * back. Those differ often enough to matter: the prompt tells the model to
+   * return text already in the target language untouched, and a translation
+   * can fail into an echo of the source. Reading 动画 with an English voice is
+   * not an accent, it is noise.
+   *
+   * Script settles it wherever script can. It is the dependable half of
+   * language identification — telling Spanish from Portuguese takes a whole
+   * sentence, but no quantity of Han is English — and it decides the two
+   * characters that chrome.i18n.detectLanguage cannot judge at all.
+   *
+   * @param {string} text
+   * @param {string} declared the target language the caller asked for, if any
+   * @param {() => Promise<string>} detect statistical detection, the last resort
+   */
+  async function resolveSpokenLang(text, declared, detect) {
+    const script = scriptOf(text);
+    if (script) {
+      // zh-CN and zh-TW both reduce to `zh`; keep the caller's finer answer.
+      return baseOf(declared) === script ? declared : script;
+    }
+    // The text carries no CJK, so a CJK target is the wrong voice to read it
+    // with — whatever it is, it is not that.
+    if (declared && !CJK_SCRIPT[baseOf(declared)]) return declared;
+    const detected = typeof detect === 'function' ? await detect() : '';
+    return detected || declared || '';
+  }
+
+  root.SpeechLang = { SPEECH_REGION, CJK_SCRIPT, scriptOf, resolveSpeechLang, resolveSpokenLang };
+})(globalThis);

--- a/test/unit/content-speech.test.mjs
+++ b/test/unit/content-speech.test.mjs
@@ -18,6 +18,17 @@ const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, imp
 
 const OWNER = 'content/content-speech.js';
 
+await import('../../shared/speech-lang.js');
+const { SPEECH_REGION, scriptOf, resolveSpeechLang, resolveSpokenLang } = globalThis.SpeechLang;
+
+// A stand-in for what speechSynthesis.getVoices() hands back on macOS: every
+// entry region-qualified, never a bare tag, and several regions per language.
+const VOICES = [
+  'zh-CN', 'zh-TW', 'zh-HK', 'en-US', 'en-GB', 'en-AU', 'ja-JP', 'ko-KR',
+  'fr-FR', 'fr-CA', 'de-DE', 'es-ES', 'es-MX', 'pt-BR', 'pt-PT', 'ru-RU',
+  'it-IT', 'nl-NL',
+].map((lang) => ({ lang }));
+
 // Every script the manifest injects, minus the owner itself.
 function otherContentScripts() {
   const manifest = JSON.parse(repoFile('manifest.json'));
@@ -71,6 +82,85 @@ test('the owner loads before every surface that uses it', () => {
     assert.ok(ownerAt < scripts.indexOf(consumer),
       `${OWNER} must load before ${consumer}, which reads ctx.speech at module scope`);
   }
+});
+
+// ==================== which voice actually speaks ====================
+//
+// The bug these cover: Chrome matches `utterance.lang` against the installed
+// voices and answers no match with the SYSTEM DEFAULT voice, not a near one.
+// No installed voice carries a bare tag, and eight of our ten targets are
+// bare — so picking English on a Chinese-locale Mac read the English aloud
+// with 婷婷.
+
+test('a bare target language is widened to a tag some voice answers to', () => {
+  for (const [base, expected] of Object.entries(SPEECH_REGION)) {
+    assert.equal(resolveSpeechLang(base, VOICES), expected,
+      `'${base}' must resolve to an installed voice's tag, or Chrome uses the system default`);
+  }
+});
+
+test('every language the picker offers can be spoken', () => {
+  // The same drift target/unit/target-languages.test.mjs guards for the prompt:
+  // a language offered but not mapped here is silently read in the wrong voice.
+  const bootstrap = repoFile('content/content-bootstrap.js');
+  const block = bootstrap.slice(bootstrap.indexOf('TARGET_LANGUAGE_OPTIONS: ['));
+  const offered = [...block.slice(0, block.indexOf(']')).matchAll(/value: '([^']+)'/g)].map((m) => m[1]);
+  assert.ok(offered.length >= 10, `expected the full target list, saw ${offered.join(', ')}`);
+
+  for (const lang of offered) {
+    const resolved = resolveSpeechLang(lang, VOICES);
+    assert.ok(VOICES.some((v) => v.lang === resolved),
+      `target '${lang}' resolves to '${resolved}', which no voice answers to — add it to SPEECH_REGION`);
+  }
+});
+
+test('a tag a voice already answers to is left alone', () => {
+  // zh-CN and zh-TW are different voices, not two spellings of one.
+  assert.equal(resolveSpeechLang('zh-TW', VOICES), 'zh-TW');
+  assert.equal(resolveSpeechLang('en-GB', VOICES), 'en-GB');
+  // A language with no map entry still beats the system default.
+  assert.equal(resolveSpeechLang('nl', VOICES), 'nl-NL');
+  // Nothing installed for it: hand back the tag rather than invent a region.
+  assert.equal(resolveSpeechLang('sw', VOICES), 'sw');
+  // No list to check against yet — same, rather than guessing.
+  assert.equal(resolveSpeechLang('en', []), 'en');
+});
+
+test('script decides the language when the text disagrees with the target', async () => {
+  const never = () => { throw new Error('detection should not be reached'); };
+
+  // The reported case: translating 动画 into English echoed the source back,
+  // and the translation button read Chinese with an English voice.
+  assert.equal(await resolveSpokenLang('动画', 'en', never), 'zh');
+  assert.equal(await resolveSpokenLang('안녕하세요', 'en', never), 'ko');
+  assert.equal(await resolveSpokenLang('こんにちは', 'en', never), 'ja');
+  // Kanji beside kana is Japanese, not Chinese.
+  assert.equal(await resolveSpokenLang('日本語を話す', 'en', never), 'ja');
+  // The target agrees, so its finer form survives: zh-TW must not become zh.
+  assert.equal(await resolveSpokenLang('動畫', 'zh-TW', never), 'zh-TW');
+});
+
+test('detection is the last resort, not the first', async () => {
+  // Latin text with a Latin target: no reason to spend a detection call, and
+  // no reason to doubt the target.
+  assert.equal(await resolveSpokenLang('animation', 'en', () => { throw new Error('no'); }), 'en');
+  // Latin text with a CJK target is the target being wrong; ask.
+  assert.equal(await resolveSpokenLang('animation', 'zh-CN', async () => 'en'), 'en');
+  // Detection has nothing to say on two characters — better the declared
+  // target than an empty tag, which is the system default voice again.
+  assert.equal(await resolveSpokenLang('xy', 'fr', async () => ''), 'fr');
+  assert.equal(scriptOf('animation'), '');
+});
+
+test('the pure half is loaded before the module that uses it', () => {
+  const manifest = JSON.parse(repoFile('manifest.json'));
+  const scripts = manifest.content_scripts.find((entry) => entry.js.includes(OWNER)).js;
+  const at = scripts.indexOf('shared/speech-lang.js');
+  assert.ok(at !== -1, 'manifest.json must inject shared/speech-lang.js');
+  assert.ok(at < scripts.indexOf(OWNER), 'shared/speech-lang.js must load before ' + OWNER);
+  // And the owner must not grow its own copy of the resolution it delegates.
+  assert.doesNotMatch(repoFile(OWNER), /SPEECH_REGION\s*=/,
+    `${OWNER} redeclares the region map — it belongs to shared/speech-lang.js`);
 });
 
 test('every string this feature added has a translation in all locales', () => {


### PR DESCRIPTION
## Summary

Read-aloud spoke almost every language in the wrong voice. Root cause, measured rather than guessed: Chrome matches `utterance.lang` against the installed voices, and **when nothing matches it uses the system default voice, not a near neighbour**. Probing the real list on this machine — 180 voices, every one region-qualified (`en-US`, `ja-JP`, `fr-FR`), **zero bare tags**, default `zh-CN|婷婷`. Eight of the ten targets the picker offers are bare codes (`en`, `ja`, `ko`, `fr`, `de`, `es`, `pt`, `ru`), and so are the codes `chrome.i18n.detectLanguage` returns. So the common case was the broken one: picking English set `lang = 'en'`, matched nothing, and read the English aloud with 婷婷.

Two smaller causes on the same path:

- `getVoices()` is empty until the engine has enumerated; resolving against it before `voiceschanged` fell back to the raw tag — the same bug by another route. The first utterance now waits.
- The declared target is what we *asked the translator for*, not what came back. The prompt tells the model to return already-target-language text untouched, and a translation can fail into an echo of the source — so 动画 "translated" to English was read with an English voice. Script is the dependable half of language identification (no quantity of Han is English), so Han/kana/hangul now overrides a disagreeing declared target; statistical detection stays the last resort.

Only `utterance.lang` is ever set, never `utterance.voice`. Picking a voice ourselves would mean ranking macOS's 41 English voices with no signal for which are ordinary and which are novelties — first alphabetically is Albert, and "Bad News" and "Bells" are in the list.

## Changed Files

- `shared/speech-lang.js` **(new)** — the pure half: `resolveSpeechLang(lang, voices)` widens a tag until some installed voice answers to it; `resolveSpokenLang(text, declared, detect)` decides which language to speak at all. Same `shared/` precedent as `api-compat.js` / `caption-core.js`, so the unit suite drives it against a fixed voice list instead of whatever the test machine has installed.
- `content/content-speech.js` — delegates to it, and waits for `voiceschanged` before the first utterance.
- `manifest.json` — injects `shared/speech-lang.js` before `content/content-speech.js`.
- `test/unit/content-speech.test.mjs` — 6 tests, including one that ties `SPEECH_REGION` to `TARGET_LANGUAGE_OPTIONS` in `content/content-bootstrap.js`, so a language added to the picker and not mapped here fails the suite instead of being silently read in the wrong voice (the guard `target-languages.test.mjs` already applies to the prompt), and one asserting the owner does not regrow its own copy of the region map.

## Validation

- `npm run test:unit` — 141 passed, 0 failed.
- `npm run test:e2e` — 112 passed. Three failures are unrelated: `clipped-container-translation` passed on re-run (flake), and the two `comic-account` sign-in specs fail identically on a pristine `main` worktree at 9bcc20d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)