### PR TITLE
fix(input dialog): stop returning typed text untranslated

### DIFF
--- a/content/content-input-dialog.js
+++ b/content/content-input-dialog.js
@@ -250,7 +250,11 @@
           type: 'TRANSLATE',
           text: text,
           targetLang: targetLang,
-          mode: isInputDictionaryText(text) ? 'word' : 'text'
+          mode: isInputDictionaryText(text) ? 'word' : 'text',
+          // 这段文字是用户敲进来的，跟当前页面没有任何关系。不声明的话，内置
+          // 引擎会拿页面语言当源语言，于是在英文页面上输入“动画”翻成英文就变成
+          // en→en，被同语言短路原样退回。
+          standaloneText: true
         });
 
         if (response.error) {

--- a/content/content-translation-engine.js
+++ b/content/content-translation-engine.js
@@ -108,18 +108,22 @@
   // 逐块判更准，所以这里缓存页面级结果。
   let pageSourceLangPromise = null;
 
-  async function detectLanguageOf(text, requireReliable) {
+  // CLD 在几个字符上基本是在猜，短样本直接不问。独立文本（输入框）会按字母体系
+  // 放宽这个下限——一两个汉字或假名已经足够定语言，见 resolveStandaloneSourceLang。
+  const DETECT_MIN_CHARS = 8;
+
+  // requireReliable 默认关：页面级取样 4000 字，本来就稳，卡这道门槛只会让整页
+  // 退化成没有源语言可用。块级和纯拉丁的独立文本才打开它。
+  async function detectLanguageOf(text, { requireReliable = false, minChars = DETECT_MIN_CHARS } = {}) {
     if (!chrome?.i18n?.detectLanguage) return '';
     const sample = ctx.getLanguageDetectionText
       ? ctx.getLanguageDetectionText(text)
       : String(text || '').slice(0, 400);
-    if (!sample || sample.length < 8) return '';
+    if (!sample || sample.length < minChars) return '';
     try {
       const result = await chrome.i18n.detectLanguage(sample);
       const top = result?.languages?.[0];
       if (!top || !top.language || top.language === 'und') return '';
-      // 块级探测才要求“判得准”。页面级取样 4000 字，本来就稳，
-      // 卡这道门槛只会让整页退化成没有源语言可用。
       if (requireReliable && (result.isReliable !== true || (top.percentage || 0) < 70)) {
         return '';
       }
@@ -148,16 +152,64 @@
   // 短文本（划词、悬停、字幕）自身的探测结果不可靠，交给页面级结果兜底。
   const SELF_DETECT_MIN_CHARS = 40;
 
-  async function resolveSourceLang(text, hint) {
-    if (hint) return toApiLang(hint);
+  // SUPPORTED_LANGS 里用非拉丁字母书写的那些。判断“页面语言可不可能是这段文字的
+  // 语言”只需要这一条：字母体系对不上就一定不是。
+  //
+  // 从 SUPPORTED_LANGS 派生，不另抄一张表：zh→Hans、bg→Cyrl 这些 Intl 自己就
+  // 知道，而往 SUPPORTED_LANGS 里加语言的人不该还要记得同步第二处——漏掉一门
+  // 非拉丁语言，正是下面这个 bug 原样复发。
+  const NON_LATIN_LANGS = new Set([...SUPPORTED_LANGS].filter((lang) => {
+    try {
+      return new Intl.Locale(lang).maximize().script !== 'Latn';
+    } catch (error) {
+      // 认不出来就当非拉丁：这个集合只用来否决页面语言，多否决一次最多是源语言
+      // 猜成 en（拉丁文本照样译得出来），少否决一次就是原文原样退回。
+      return true;
+    }
+  }));
+  // Script=Common 涵盖数字、标点、空白和 emoji，Inherited 涵盖组合用附加符号，
+  // 所以 "hello 😀" 和 "café" 都仍算纯拉丁。
+  const HAS_NON_LATIN_CHARS = /[^\p{Script=Latin}\p{Script=Common}\p{Script=Inherited}]/u;
+
+  /**
+   * 输入框里的文字不属于这个页面：读英文页面时想把“动画”翻成英文是常事。拿页面
+   * 语言当源语言会得出 src='en'、tgt='en'，被同语言短路原样返回——用户选了目标
+   * 语言、点了翻译，拿回来的还是自己输入的那行字。反过来同样成立：在中文页面上
+   * 输入 "animation" 想要中文，会被判成 zh→zh 原样退回。
+   *
+   * 短文本上 CLD 唯一可靠的线索是字母体系。实测（headless Chrome，全部
+   * isReliable=false）：动画→zh、アニメ→ja、안녕→ko、привет→ru 都对，而同样
+   * 长度的拉丁字母全错——hello→sr、animation→ja、Bonjour→no、ok→pl。几十种
+   * 拉丁语言在一两个词上本来就分不开。所以只在文本自身带非拉丁字符时才采信
+   * “判得不准”的结果，纯拉丁文本仍旧要求 isReliable。
+   */
+  async function resolveStandaloneSourceLang(trimmed) {
+    const nonLatinText = HAS_NON_LATIN_CHARS.test(trimmed);
+    const detected = toApiLang(await detectLanguageOf(trimmed, {
+      minChars: nonLatinText ? 2 : DETECT_MIN_CHARS,
+      requireReliable: !nonLatinText
+    }));
+    if (detected && SUPPORTED_LANGS.has(detected)) return detected;
+
     const pageLang = toApiLang(await getPageSourceLang());
+    if (pageLang && NON_LATIN_LANGS.has(pageLang) === nonLatinText) return pageLang;
+    // 字母体系对不上，页面语言出局。剩下的拉丁文本按英文处理：拉丁字母里英文
+    // 是压倒性的多数，而这里的备选不是“更好的猜测”，是彻底放弃。非拉丁文本走
+    // 到这里说明连字母体系都没给出答案，那就交给 AI，模型自己会认源语言。
+    return nonLatinText ? '' : 'en';
+  }
+
+  async function resolveSourceLang(text, hint, standalone) {
+    if (hint) return toApiLang(hint);
     const trimmed = String(text || '').trim();
+    if (standalone) return resolveStandaloneSourceLang(trimmed);
+    const pageLang = toApiLang(await getPageSourceLang());
     if (trimmed.length >= SELF_DETECT_MIN_CHARS) {
       // 块级结果只在“判得准、且判出来的语言内置引擎确实支持”时才采信。
       // 逐块探测存在的意义是混合语言页面（英文正文里夹日文引用），那是少数派；
       // 而技术文章里满是型号名、版本号和百分数，CLD 判歪一段很常见 —— 一旦判歪，
       // 这一段就变成不支持的语言对。宁可整段按页面主语言处理，也不能被一次误判带走。
-      const own = toApiLang(await detectLanguageOf(trimmed, true));
+      const own = toApiLang(await detectLanguageOf(trimmed, { requireReliable: true }));
       if (own && SUPPORTED_LANGS.has(own)) return own;
     }
     return pageLang;
@@ -429,7 +481,7 @@
     if (!source.trim()) return source;
 
     const tgt = toApiLang(targetLang);
-    const src = await resolveSourceLang(source, options.sourceLang);
+    const src = await resolveSourceLang(source, options.sourceLang, options.standaloneText);
 
     if (!src || !tgt) throw new EngineUnavailableError(ENGINE_REASONS.UNSUPPORTED_PAIR);
     // 同语言不需要翻译。原样返回，与 AI 那条路“已是目标语言则原样返回”的约定一致。
@@ -559,7 +611,9 @@
     const targetLang = message.targetLang;
     const shared = {
       sourceLang: message.sourceLang,
-      allowDownload: message.allowDownload
+      allowDownload: message.allowDownload,
+      // 输入框的文本是用户自己敲的，与页面无关。见 resolveSourceLang。
+      standaloneText: message.standaloneText === true
     };
 
     switch (message.type) {

--- a/test/unit/helpers/engine-harness.mjs
+++ b/test/unit/helpers/engine-harness.mjs
@@ -1,0 +1,98 @@
+// Enough of a browser for content/content-translation-engine.js to install
+// itself and run in Node.
+//
+// The engine caches the page's language for the life of the document, so a
+// test file gets exactly one page language. Anything that needs a different
+// one needs its own file — `node --test` gives each file its own process.
+//
+// Not used by builtin-translator-stall.test.mjs, which has its own harness
+// wired for the download/stall clock.
+
+// What headless Chrome's chrome.i18n.detectLanguage actually answers. Every
+// one of these comes back isReliable=false: CJK is named correctly from a
+// couple of characters, and short Latin input is nonsense.
+const LATIN_MISREADS = { hello: 'sr', animation: 'ja', Bonjour: 'no', ok: 'pl' };
+
+export function detectLanguage(sample) {
+  const text = String(sample || '');
+  if (/[一-鿿]/.test(text)) {
+    return { isReliable: text.length >= 40, languages: [{ language: 'zh', percentage: 100 }] };
+  }
+  if (/[ぁ-ゟ゠-ヿ]/.test(text)) {
+    return { isReliable: false, languages: [{ language: 'ja', percentage: 100 }] };
+  }
+  if (!/[a-z]/i.test(text)) return { isReliable: false, languages: [] };
+  // Only a page-sized Latin sample is vouched for; short ones get CLD's real,
+  // wrong answers.
+  if (text.length >= 40) return { isReliable: true, languages: [{ language: 'en', percentage: 99 }] };
+  return { isReliable: false, languages: [{ language: LATIN_MISREADS[text.trim()] || 'ja', percentage: 100 }] };
+}
+
+/**
+ * Install the fakes and load the engine. Must be awaited before anything
+ * touches `ctx`, and called once per process.
+ */
+export async function installEngineHarness({ pageText }) {
+  const translateCalls = [];
+  const sentToAI = [];
+  const state = { apiKey: '' };
+
+  globalThis.self = {
+    isSecureContext: true,
+    Translator: {
+      availability: async () => 'available',
+      create: async ({ sourceLanguage, targetLanguage }) => ({
+        translate: async (text) => {
+          translateCalls.push({ sourceLanguage, targetLanguage, text });
+          return `builtin(${sourceLanguage}->${targetLanguage}):${text}`;
+        },
+        destroy() {},
+      }),
+    },
+  };
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { userActivation: { isActive: true } },
+    configurable: true,
+    writable: true,
+  });
+  globalThis.window = {
+    AI_TRANSLATOR_CONTENT: {
+      // content/content-language.js installs this in the real extension; the
+      // engine reads it to build the detection sample.
+      getLanguageDetectionText(text) {
+        if (!text) return '';
+        return text.replace(/\{\{\d+\}\}/g, '').replace(/\s+/g, ' ').trim().slice(0, 400);
+      },
+    },
+    addEventListener() {},
+    removeEventListener() {},
+  };
+  globalThis.window.top = globalThis.window;
+  globalThis.document = { body: { innerText: pageText } };
+  globalThis.chrome = {
+    i18n: { detectLanguage: async (sample) => detectLanguage(sample) },
+    storage: {
+      sync: { get: async () => ({ apiKey: state.apiKey }) },
+      onChanged: { addListener() {} },
+    },
+    runtime: {
+      sendMessage: async (message) => {
+        sentToAI.push(message);
+        return { translation: `AI:${message.text}`, phonetic: '', isWord: false };
+      },
+    },
+  };
+
+  // The engine narrates every fallback; assertions do the talking here.
+  console.info = () => {};
+  console.warn = () => {};
+
+  await import('../../../content/content-translation-engine.js');
+
+  return {
+    ctx: globalThis.window.AI_TRANSLATOR_CONTENT,
+    translateCalls,
+    sentToAI,
+    setApiKey(key) { state.apiKey = key; },
+  };
+}

--- a/test/unit/input-dialog-source-lang-cjk-page.test.mjs
+++ b/test/unit/input-dialog-source-lang-cjk-page.test.mjs
@@ -1,0 +1,53 @@
+// The mirror of the reported bug, and the more common one for this
+// extension's users: on a Chinese page, typing "animation" into the input
+// dialog and asking for Chinese gave src='zh', tgt='zh' — the equal-language
+// short-circuit handed the word straight back.
+//
+// Separate file from input-dialog-source-lang.test.mjs because the engine
+// caches the page's language for the life of the document, so one page
+// language per process.
+//
+// Run with: npm run test:unit
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { installEngineHarness } from './helpers/engine-harness.mjs';
+
+const CHINESE_PAGE = '这是一个中文网页，正文里全部都是中文句子，用来给页面语言探测取样。'.repeat(20);
+
+const { ctx, translateCalls } = await installEngineHarness({ pageText: CHINESE_PAGE });
+
+function typedIntoDialog(text, targetLang) {
+  return ctx.requestTranslation({
+    type: 'TRANSLATE',
+    text,
+    targetLang,
+    mode: 'text',
+    standaloneText: true,
+  });
+}
+
+test('an English word typed on a Chinese page is translated, not echoed back', async () => {
+  translateCalls.length = 0;
+  const result = await typedIntoDialog('animation', 'zh-CN');
+
+  assert.notEqual(result.translation, 'animation', 'the input came straight back untranslated');
+  assert.equal(translateCalls.length, 1, 'nothing was handed to the built-in translator');
+  assert.equal(translateCalls[0].sourceLanguage, 'en', 'the page language was used as the source');
+  assert.equal(translateCalls[0].targetLanguage, 'zh');
+});
+
+test('the page language is only rejected when its script disagrees', async () => {
+  // A Chinese word typed on a Chinese page is Chinese; nothing here should
+  // push the source away from the page just because the text was typed.
+  translateCalls.length = 0;
+  await typedIntoDialog('动画', 'en');
+
+  assert.equal(translateCalls[0].sourceLanguage, 'zh');
+});
+
+test('page text on a Chinese page still falls back to the page language', async () => {
+  translateCalls.length = 0;
+  await ctx.requestTranslation({ type: 'TRANSLATE', text: '更多', targetLang: 'en', mode: 'text' });
+
+  assert.equal(translateCalls[0].sourceLanguage, 'zh', 'lost the page-language fallback');
+});

--- a/test/unit/input-dialog-source-lang.test.mjs
+++ b/test/unit/input-dialog-source-lang.test.mjs
@@ -1,0 +1,96 @@
+// The input dialog is a scratchpad. What you type into it has nothing to do
+// with the page it happens to be open on — you can be reading an English page
+// and want a Chinese word turned into English.
+//
+// The built-in engine did not know that. `resolveSourceLang()` self-detects
+// only from 40 characters up; below that it takes the *page's* language as the
+// source. So typing 动画 on an English page gave src='en', tgt='en', and
+// `translateWithBuiltin` short-circuits equal languages by returning the input
+// untouched. The reported symptom was exactly that: pick English, press
+// 翻译, get 动画 back.
+//
+// Built-in is the default engine, so this is what most users hit.
+//
+// This file is the English-page half; the Chinese-page half is in
+// input-dialog-source-lang-cjk-page.test.mjs, because the engine caches the
+// page language for the life of the document.
+//
+// Run with: npm run test:unit
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { installEngineHarness } from './helpers/engine-harness.mjs';
+
+const ENGLISH_PAGE = 'The quick brown fox jumps over the lazy dog, again and again. '.repeat(20);
+
+const { ctx, translateCalls } = await installEngineHarness({ pageText: ENGLISH_PAGE });
+
+function typedIntoDialog(text, targetLang) {
+  return ctx.requestTranslation({
+    type: 'TRANSLATE',
+    text,
+    targetLang,
+    mode: 'text',
+    standaloneText: true,
+  });
+}
+
+// ==================== the reported bug ====================
+
+test('a Chinese word typed on an English page is translated, not echoed back', async () => {
+  translateCalls.length = 0;
+  const result = await typedIntoDialog('动画', 'en');
+
+  assert.notEqual(result.translation, '动画', 'the input came straight back untranslated');
+  assert.equal(translateCalls.length, 1, 'nothing was handed to the built-in translator');
+  assert.equal(translateCalls[0].sourceLanguage, 'zh', 'the page language was used as the source');
+  assert.equal(translateCalls[0].targetLanguage, 'en');
+});
+
+test('the page language is never consulted for text that was typed', async () => {
+  // The page is English throughout this file, and this phrase is far under the
+  // 40 characters that block-level self-detection needs.
+  translateCalls.length = 0;
+  await typedIntoDialog('这是一段很短的中文', 'en');
+
+  assert.equal(translateCalls[0].sourceLanguage, 'zh');
+});
+
+test('text that really is in the target language still comes back untouched', async () => {
+  // The equal-language short-circuit is right; it was being fed the wrong
+  // source. Typing English and asking for English is a genuine no-op.
+  translateCalls.length = 0;
+  const result = await typedIntoDialog('the quick brown fox', 'en');
+
+  assert.equal(result.translation, 'the quick brown fox');
+  assert.equal(translateCalls.length, 0, 'asked the translator to convert en to en');
+});
+
+test('a short Latin word is not translated as whatever CLD guessed', async () => {
+  // CLD really does answer 'ja' for "animation" and 'sr' for "hello". Trusting
+  // that would hand the built-in translator the wrong source language and turn
+  // one bug into another, so an unreliable answer is only believed when the
+  // script itself pins the language.
+  translateCalls.length = 0;
+  await typedIntoDialog('animation', 'zh-CN');
+
+  assert.equal(translateCalls[0].sourceLanguage, 'en', 'believed the guess that animation is Japanese');
+});
+
+test('kana is read as Japanese even on an English page', async () => {
+  translateCalls.length = 0;
+  await typedIntoDialog('アニメ', 'en');
+
+  assert.equal(translateCalls[0].sourceLanguage, 'ja');
+});
+
+// ==================== the page's own text is unaffected ====================
+
+test('page text still falls back to the page language when it is too short to detect', async () => {
+  // Selection, hover and whole-page translation all send text that came off
+  // the page, where the page's language is the best available answer for a
+  // fragment too short to detect on its own. That behaviour has to stay.
+  translateCalls.length = 0;
+  await ctx.requestTranslation({ type: 'TRANSLATE', text: 'Read more', targetLang: 'ja', mode: 'text' });
+
+  assert.equal(translateCalls[0].sourceLanguage, 'en', 'lost the page-language fallback');
+});

--- a/test/unit/target-languages.test.mjs
+++ b/test/unit/target-languages.test.mjs
@@ -64,6 +64,26 @@ test('the settings page and the in-page picker offer the same languages', () => 
   assert.deepEqual(pickerLanguages().slice().sort(), settingsLanguages().slice().sort());
 });
 
+test('the built-in engine derives its non-Latin set instead of hand-listing it', () => {
+  // NON_LATIN_LANGS decides whether the page's language could plausibly be the
+  // language of something typed into the input dialog. A hardcoded copy would
+  // be a fifth list to keep in step, and forgetting one non-Latin language
+  // there brings back exactly the bug it exists to prevent: the typed text
+  // takes the page's language as its source and comes back untranslated.
+  const source = repoFile('content/content-translation-engine.js');
+  const start = source.indexOf('const NON_LATIN_LANGS =');
+  assert.notEqual(start, -1, 'could not find NON_LATIN_LANGS');
+  const block = source.slice(start, source.indexOf('}));', start));
+  assert.match(block, /\.\.\.SUPPORTED_LANGS/, 'NON_LATIN_LANGS stopped following SUPPORTED_LANGS');
+  assert.match(block, /Intl\.Locale/, 'a language\'s script should be Intl\'s answer, not a literal');
+
+  // And the derivation has to actually have an answer for every target we
+  // offer — a language Intl cannot place would fall to the catch branch.
+  for (const lang of settingsLanguages()) {
+    assert.ok(new Intl.Locale(lang).maximize().script, `Intl cannot place the script of '${lang}'`);
+  }
+});
+
 test('both surfaces agree with the list of accepted targets', () => {
   // Normalization in the service worker and the options page decides what
   // counts as a supported target; anything offered has to survive it.


### PR DESCRIPTION
## The bug

Picking a target language in the input dialog and pressing 翻译 could hand back
exactly what was typed: 动画 in, English selected, 动画 out.

## Root cause

Not in the picker — in the built-in engine's source-language resolution.

`resolveSourceLang()` self-detects only from 40 characters up; below that it
falls back to the **page's** language. That is right for everything else that
reaches it: selection, hover and whole-page translation all send text that came
off the page, where the page's language is the best available answer for a
fragment too short to identify on its own.

But the input dialog is a scratchpad — what you type into it has no relation to
the page it happens to be open on. Typing 动画 on an English page resolved to
`src=en, tgt=en`, and `translateWithBuiltin`'s equal-language short-circuit
returned the input untouched. The mirror case is the same bug and the more
common one for this extension's users: `animation` typed on a Chinese page and
asked for Chinese resolves `zh→zh` and comes straight back.

Built-in is the default engine (only `translationEngine === 'ai'` opts out), so
this is what most users hit. The AI path is unaffected — there the model reads
the text itself.

## The fix

The dialog marks its request `standaloneText: true`; the engine resolves that
from the text rather than from the page.

Detection at word length needed measuring rather than guessing. Probed against
headless Chrome, **every** answer comes back `isReliable: false`, and the useful
ones are exactly the ones a distinct script pins down:

| input | CLD says | |
| --- | --- | --- |
| 动画 | `zh` | ✅ |
| アニメ | `ja` | ✅ |
| 안녕 | `ko` | ✅ |
| привет | `ru` | ✅ |
| hello | `sr` | ❌ |
| animation | `ja` | ❌ |
| Bonjour | `no` | ❌ |
| ok | `pl` | ❌ |

Dozens of languages share the Latin alphabet, so one or two words carry almost
no signal. (Chrome's newer `LanguageDetector` API is no way out either — it
reports `unavailable` in that build.)

So simply lowering the detection floor would have traded this bug for another
one, translating the typed word "animation" as Japanese. Instead an unreliable
answer is believed only when the text itself carries non-Latin characters;
pure-Latin text still has to pass `isReliable`, and falls back to the page
language only when that language's script agrees with the text's.

`NON_LATIN_LANGS` is **derived** from `SUPPORTED_LANGS` via
`Intl.Locale(lang).maximize().script` rather than hand-listed — verified to
reproduce the hand-written list exactly. A literal copy would be a fifth
language list to keep in step with the other four, and dropping one non-Latin
language from it reintroduces precisely this bug.

## Changed files

- `content/content-input-dialog.js` — mark the typed text as standalone
- `content/content-translation-engine.js` — `resolveStandaloneSourceLang()`, derived `NON_LATIN_LANGS`, `detectLanguageOf()` takes an options object
- `test/unit/helpers/engine-harness.mjs` — shared fake browser (new)
- `test/unit/input-dialog-source-lang.test.mjs` — English page (new)
- `test/unit/input-dialog-source-lang-cjk-page.test.mjs` — Chinese page, the mirror case (new)
- `test/unit/target-languages.test.mjs` — fails if `NON_LATIN_LANGS` stops being derived

Two unit files rather than one because the engine caches the page's language for
the life of the document, so a test process gets one page language.

## Validation

- `npm run test:unit` — 140/140 pass on this branch.
- The shared fake detector reproduces the measured CLD behaviour, wrong Latin
  answers included, so a fix that merely lowers the floor fails.
- A/B: disabling the standalone branch fails 4 of the 9 new tests, in both
  directions of the bug.
- `npx playwright test test/e2e/input-translation.spec.js` — 3/3 pass.
- Full `npm run test:e2e` was also run. `test/e2e/comic-account.spec.js` has a
  **pre-existing** flake under full-suite load: a pristine `origin/main`
  worktree fails there too (a different test in the same file), while the whole
  spec file passes in 37s when run alone on either tree. Unrelated to this
  change and worth fixing separately.

## ⚠️ Not reviewed by the bot

`@codex review` returned *"You have reached your Codex usage limits for code
reviews"* twice. The workflow script counted that as bot activity and declared
merge-ready; it is not a review. This needs human eyes before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
