### PR TITLE
fix(speech): pick the voice ourselves — Chrome's first tag match is a no

### DIFF
--- a/content/content-speech.js
+++ b/content/content-speech.js
@@ -126,8 +126,18 @@
     if (token !== requestToken) return false;
 
     const utterance = new SpeechSynthesisUtterance(trimmed);
-    const voiceLang = SpeechLang.resolveSpeechLang(spokenLang, window.speechSynthesis.getVoices());
-    if (voiceLang) utterance.lang = voiceLang;
+    // The voice is set explicitly, not left to the tag: Chrome answers a bare
+    // tag with the first listed match, and macOS lists its novelty voices
+    // first — `en-US` alone means Albert, the hoarse croak.
+    const voices = window.speechSynthesis.getVoices();
+    const voice = SpeechLang.pickVoice(spokenLang, voices);
+    if (voice) {
+      utterance.voice = voice;
+      utterance.lang = voice.lang;
+    } else {
+      const voiceLang = SpeechLang.resolveSpeechLang(spokenLang, voices);
+      if (voiceLang) utterance.lang = voiceLang;
+    }
 
     const finish = () => {
       if (token !== requestToken) return;

--- a/shared/speech-lang.js
+++ b/shared/speech-lang.js
@@ -1,11 +1,13 @@
-// AI Translator — choosing the language a read-aloud button speaks in.
+// AI Translator — choosing the language and the voice a read-aloud button
+// speaks with.
 //
-// Two questions, both easy to get wrong, both pure, so they live here where
+// Three questions, all easy to get wrong, all pure, so they live here where
 // `npm run test:unit` can exercise them against a synthetic voice list rather
 // than against whichever voices the machine running the tests happens to have.
 //
 //   1. What language is this text actually in?   resolveSpokenLang()
 //   2. What tag will an installed voice answer to? resolveSpeechLang()
+//   3. Which of the voices answering should speak? pickVoice()
 //
 // Question 2 is the one that made every non-Chinese target unintelligible.
 // Chrome matches `utterance.lang` against the installed voices, and when
@@ -16,6 +18,13 @@
 // chrome.i18n.detectLanguage returns. So the common case was the broken one:
 // choosing English on a Chinese-locale Mac set `lang = 'en'`, matched nothing,
 // and read the English out with 婷婷, the system default.
+//
+// Question 3 is why a correct tag still came out hoarse. When `utterance.voice`
+// is unset, Chrome takes the FIRST voice in its list that matches the tag, not
+// the language's flagship — and macOS enumerates voices alphabetically, so
+// `en-US` lands on Albert, a croaking novelty voice, with Samantha at 131.
+// Japanese lands on Eddy, an Eloquence robot, with Kyoko behind it. The tag
+// fix moved the failure from "wrong language" to "right language, joke voice".
 //
 // Loaded as a classic script by the content scripts, so it publishes onto the
 // global object rather than using `export`.
@@ -61,11 +70,11 @@
   /**
    * Widen a language tag until some installed voice answers to it.
    *
-   * Only the tag is ever set, never `utterance.voice`: once the tag matches,
-   * the engine picks that language's preferred voice. Choosing one ourselves
-   * would mean ranking the 41 English voices macOS installs with no signal for
-   * which are ordinary and which are novelties — the first alphabetically is
-   * Albert, and "Bad News" and "Bells" are in there too.
+   * The widened tag is only half the answer: left to match it alone, Chrome
+   * takes the first listed voice for the tag, which on macOS is a novelty.
+   * pickVoice() below chooses the voice that actually speaks; this keeps
+   * choosing the tag, which is also the fallback when pickVoice has no list
+   * to rank yet.
    *
    * @param {string} lang
    * @param {Array<{lang: string}>} voices speechSynthesis.getVoices()
@@ -91,6 +100,69 @@
     // to the system default voice.
     const installed = list.find((voice) => baseOf(tagOf(voice)) === baseOf(tag));
     return installed ? tagOf(installed) : tag;
+  }
+
+  // macOS ships two families of deliberately unnatural voices in the same list
+  // as the real ones, and on a machine with nothing else installed they are
+  // what alphabetical order serves first.
+  //
+  // The novelty voices are sound-effect jokes — Albert is a hoarse croak,
+  // Bells sings, Whisper whispers. Kathy, Fred, Junior and Ralph are their
+  // 1980s-era siblings. None of them should ever read a translation while any
+  // natural voice for the language is installed.
+  const NOVELTY_VOICES = new Set([
+    'Albert', 'Bad News', 'Bahh', 'Bells', 'Boing', 'Bubbles', 'Cellos',
+    'Fred', 'Good News', 'Jester', 'Junior', 'Kathy', 'Organ', 'Ralph',
+    'Superstar', 'Trinoids', 'Whisper', 'Wobble', 'Zarvox',
+  ]);
+  // The Eloquence voices are intelligible but robotic — kept by Apple for
+  // screen-reader users who prefer them. Each name repeats across every
+  // language with a localized parenthetical ("Eddy (英语（美国）)"), which is
+  // why matching is on the family name before the parenthesis.
+  const ELOQUENCE_VOICES = new Set([
+    'Eddy', 'Flo', 'Grandma', 'Grandpa', 'Reed', 'Rocko', 'Sandy', 'Shelley',
+  ]);
+
+  /** 2 a natural voice, 1 an Eloquence robot, 0 a novelty joke. */
+  function voiceTier(voice) {
+    const family = String(voice?.name || '').split(' (')[0].trim();
+    if (NOVELTY_VOICES.has(family)) return 0;
+    if (ELOQUENCE_VOICES.has(family)) return 1;
+    return 2;
+  }
+
+  /**
+   * The voice that should read text in `lang`, or null to leave the choice to
+   * the engine (no list yet, or nothing installed for the language).
+   *
+   * Ranking: natural beats Eloquence beats novelty; within a tier the system
+   * default voice wins, then list order — which is how ties were broken before
+   * this function existed, minus the joke voices that made ties dangerous.
+   *
+   * @param {string} lang
+   * @param {Array<{name: string, lang: string, default?: boolean}>} voices
+   */
+  function pickVoice(lang, voices) {
+    const list = Array.isArray(voices) ? voices : [];
+    const tag = resolveSpeechLang(lang, list);
+    if (!tag || !list.length) return null;
+
+    const canon = (value) => String(value || '').replace('_', '-').toLowerCase();
+    let candidates = list.filter((voice) => canon(voice?.lang) === canon(tag));
+    if (!candidates.length) {
+      candidates = list.filter((voice) => baseOf(voice?.lang) === baseOf(tag));
+    }
+
+    let best = null;
+    let bestScore = -1;
+    for (const voice of candidates) {
+      const score = voiceTier(voice) * 2 + (voice?.default ? 1 : 0);
+      if (score > bestScore) {
+        best = voice;
+        bestScore = score;
+      }
+    }
+    return best;
   }
 
   /**
@@ -124,5 +196,5 @@
     return detected || declared || '';
   }
 
-  root.SpeechLang = { SPEECH_REGION, CJK_SCRIPT, scriptOf, resolveSpeechLang, resolveSpokenLang };
+  root.SpeechLang = { SPEECH_REGION, CJK_SCRIPT, scriptOf, resolveSpeechLang, resolveSpokenLang, pickVoice };
 })(globalThis);

--- a/shared/speech-lang.js
+++ b/shared/speech-lang.js
@@ -125,7 +125,10 @@
 
   /** 2 a natural voice, 1 an Eloquence robot, 0 a novelty joke. */
   function voiceTier(voice) {
-    const family = String(voice?.name || '').split(' (')[0].trim();
+    // The parenthetical's inner pair is localized (fullwidth on a Chinese
+    // system), and nothing promises the outer pair never will be — an Eddy
+    // missed here would rank as natural and out-order the real voices.
+    const family = String(voice?.name || '').split(/\s*[（(]/)[0].trim();
     if (NOVELTY_VOICES.has(family)) return 0;
     if (ELOQUENCE_VOICES.has(family)) return 1;
     return 2;
@@ -150,6 +153,9 @@
     const canon = (value) => String(value || '').replace('_', '-').toLowerCase();
     let candidates = list.filter((voice) => canon(voice?.lang) === canon(tag));
     if (!candidates.length) {
+      // Belt and braces: resolveSpeechLang only hands back a tag no voice
+      // answers to when no voice shares its base either, so this filter
+      // should never fire — but a same-base voice still beats returning null.
       candidates = list.filter((voice) => baseOf(voice?.lang) === baseOf(tag));
     }
 

--- a/test/unit/content-speech.test.mjs
+++ b/test/unit/content-speech.test.mjs
@@ -19,7 +19,7 @@ const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, imp
 const OWNER = 'content/content-speech.js';
 
 await import('../../shared/speech-lang.js');
-const { SPEECH_REGION, scriptOf, resolveSpeechLang, resolveSpokenLang } = globalThis.SpeechLang;
+const { SPEECH_REGION, scriptOf, resolveSpeechLang, resolveSpokenLang, pickVoice } = globalThis.SpeechLang;
 
 // A stand-in for what speechSynthesis.getVoices() hands back on macOS: every
 // entry region-qualified, never a bare tag, and several regions per language.
@@ -150,6 +150,60 @@ test('detection is the last resort, not the first', async () => {
   // target than an empty tag, which is the system default voice again.
   assert.equal(await resolveSpokenLang('xy', 'fr', async () => ''), 'fr');
   assert.equal(scriptOf('animation'), '');
+});
+
+// ==================== which of the matching voices speaks ====================
+//
+// The bug these cover: with `utterance.voice` unset, Chrome takes the FIRST
+// listed voice matching the tag — and macOS enumerates alphabetically, so a
+// correct `en-US` was read by Albert, a hoarse novelty voice, while Samantha
+// sat at index 131. The original sounded fine (婷婷 is the system default on a
+// Chinese-locale Mac); only the translation croaked.
+
+// The shape speechSynthesis.getVoices() actually has on that Mac: alphabetical
+// by name, novelty and Eloquence voices listed before the natural ones, the
+// system default nowhere near the language being spoken.
+const MACOS_VOICES = [
+  { name: '婷婷', lang: 'zh-CN', default: true },
+  { name: 'Albert', lang: 'en-US' },
+  { name: 'Bad News', lang: 'en-US' },
+  { name: 'Eddy (英语（美国）)', lang: 'en-US' },
+  { name: 'Eddy (日语（日本）)', lang: 'ja-JP' },
+  { name: 'Eddy (芬兰语（芬兰）)', lang: 'fi-FI' },
+  { name: 'Flo (芬兰语（芬兰）)', lang: 'fi-FI' },
+  { name: 'Grandma (英语（美国）)', lang: 'en-US' },
+  { name: 'Kyoko', lang: 'ja-JP' },
+  { name: 'Samantha', lang: 'en-US' },
+  { name: 'Whisper', lang: 'en-US' },
+];
+
+test('a natural voice beats the novelty voices listed before it', () => {
+  // The reported case: translation to English read by Albert, the croak.
+  assert.equal(pickVoice('en', MACOS_VOICES)?.name, 'Samantha');
+  // Eloquence robots are ahead of Kyoko alphabetically too.
+  assert.equal(pickVoice('ja', MACOS_VOICES)?.name, 'Kyoko');
+});
+
+test('the system default wins its own language, joke voices never inherit it', () => {
+  assert.equal(pickVoice('zh-CN', MACOS_VOICES)?.name, '婷婷');
+  // A language whose only installed voices are Eloquence still gets one —
+  // robotic in the right language beats natural in the wrong one.
+  assert.equal(pickVoice('fi-FI', MACOS_VOICES)?.name, 'Eddy (芬兰语（芬兰）)');
+});
+
+test('no candidates means no voice, not a guess', () => {
+  assert.equal(pickVoice('sw', MACOS_VOICES), null);
+  assert.equal(pickVoice('en', []), null);
+  assert.equal(pickVoice('', MACOS_VOICES), null);
+});
+
+test('the utterance is given the picked voice, not just a tag', () => {
+  // Setting only `utterance.lang` is the exact regression this guards: Chrome
+  // resolves a bare tag to the first listed match, which on macOS is a
+  // novelty voice.
+  const code = repoFile(OWNER);
+  assert.match(code, /SpeechLang\.pickVoice\(/, `${OWNER} must choose the voice through SpeechLang.pickVoice`);
+  assert.match(code, /utterance\.voice\s*=/, `${OWNER} must set utterance.voice from the picked voice`);
 });
 
 test('the pure half is loaded before the module that uses it', () => {

--- a/test/unit/content-speech.test.mjs
+++ b/test/unit/content-speech.test.mjs
@@ -182,6 +182,12 @@ test('a natural voice beats the novelty voices listed before it', () => {
   assert.equal(pickVoice('en', MACOS_VOICES)?.name, 'Samantha');
   // Eloquence robots are ahead of Kyoko alphabetically too.
   assert.equal(pickVoice('ja', MACOS_VOICES)?.name, 'Kyoko');
+  // A locale that renders the OUTER parenthesis fullwidth must not smuggle an
+  // Eloquence voice into the natural tier.
+  assert.equal(pickVoice('en', [
+    { name: 'Eddy（英语（美国））', lang: 'en-US' },
+    { name: 'Samantha', lang: 'en-US' },
+  ])?.name, 'Samantha');
 });
 
 test('the system default wins its own language, joke voices never inherit it', () => {


### PR DESCRIPTION
## Background
- This PR packages the current branch changes for review.
- It groups the current branch updates into one reviewable change.

## Solution
- fix(speech): pick the voice ourselves — Chrome's first tag match is a novelty voice

## Affected Files
- `content/content-speech.js`
- `shared/speech-lang.js`
- `test/unit/content-speech.test.mjs`