### PR TITLE
chore: release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+
+## 1.2.0 — 2026-08-10
+
+### New features
+
+- **PDF translation** (`pdf/`, account-backed): upload a PDF and receive a
+  re-typeset translated document produced server-side against the account's
+  monthly free page allowance. Ships enabled by default; requires sign-in on
+  first use. Jobs survive page navigation — the service worker polls status
+  once a minute via `chrome.alarms` and announces completion or failure via
+  `chrome.notifications` (the two permissions added in this release).
+- **Video subtitle translation on any site**: the YouTube-only caption
+  translator became a general engine (`content/content-video-captions.js` +
+  `shared/caption-core.js`) with per-site providers. Any player exposing a
+  standard `<track>`/`TextTrack` gets a bilingual overlay with no per-site
+  code; YouTube keeps its dedicated interceptor. We only translate subtitles
+  the viewer already has on, and hand tracks back exactly as found.
+- **Comic translation: colorize mode** alongside translation, hover entry
+  points that don't depend on the context menu, results that survive page
+  navigation and mode switches, and paid jobs that resume instead of
+  re-ordering.
+- **Account & free allowance**: comic and PDF translation run on our servers
+  behind a signed-in account with a monthly free page allowance. Sign-in state
+  is per device (`chrome.storage.local`), preferences per account
+  (`chrome.storage.sync`), gated everywhere through
+  `shared/account-gate.js`.
+- **Reworked translation dialog**: new layout, read-aloud (TTS) buttons for
+  source and translation, a reachable and persistent target-language picker in
+  the input-translation dialog.
+- **Options page autosave**: settings save on change; the connection test runs
+  against the endpoint exactly as configured.
+
+### Model/API compatibility
+
+- `shared/api-compat.js` is now the single owner of per-model parameter rules,
+  shared by the service worker and the options page.
+- Adapted request parameters for GPT-5.6 (`reasoning_effort` floor `'none'`),
+  Gemini 3+ (no `temperature`), and current Anthropic/OpenAI lineups; output
+  budget floors for models that bill hidden reasoning tokens.
+
+### Fixes
+
+- Host-page CSS can no longer restyle our in-page panels (scoped containment
+  reset in `content/content.css`, guarded by unit and e2e tests).
+- Read-aloud picks a real voice by language family instead of trusting
+  Chrome's first tag match, which could be a novelty voice; handles localized
+  parenthesized voice names.
+- Input-translation dialog no longer returns typed text untranslated, and
+  detects CJK source pages correctly.
+- Page translation: translations are no longer clipped away by collapsed
+  ancestors; code-highlight classes match by token, not substring.
+- Chrome's built-in Translator engine: a wedged instance is abandoned instead
+  of hanging the page.
+- Options: hotkey pairs can no longer conflict; autosave no longer talks over
+  the connection test; custom model names release the model dropdown.
+- Account gating: a signed-out device shows server-backed features as off
+  without writing that state back to sync, so it can't disable the feature on
+  a still-signed-in device.
+
+### Permissions added in this release
+
+| permission | why |
+| --- | --- |
+| `alarms` | Poll server-side PDF translation job status once a minute; MV3 service workers cannot hold long-lived timers. |
+| `notifications` | Tell the user when a PDF translation job finishes or fails, since the job outlives the page that started it. |
+
+## 1.1.1 — 2026-07-26
+
+- Comic translation (server-side redraw, account-backed).
+
+## 1.1.0 — 2026-07-18
+
+- Renamed to "AI Translator"; localized store metadata.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "__MSG_appDescription__",
   "default_locale": "en",
   "permissions": [


### PR DESCRIPTION
## Summary
- Bump manifest version 1.1.1 → 1.2.0 for Chrome Web Store submission
- Add CHANGELOG.md documenting everything shipped since 1.1.1: PDF translation, video subtitle translation on any site with a subtitle track, comic colorize mode, account/free-allowance system, reworked translation dialog with read-aloud, api-compat consolidation, and the fix list
- Records the two permissions this release adds (`alarms`, `notifications` — both for the server-side PDF job lifecycle) with their store-review justifications

## Validation
- `npm run test:unit`: 156/156 pass
- `npm run test:e2e`: 116 pass, 1 external-network flake (example.com timeout) that passes on re-run
- `npm run zip` produces ai-translator-1.2.0.zip; verified all 31 manifest-referenced files present in the archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)