### PR TITLE
fix(page-translation): [class*="language-"] 命中 Wikipedia 的 <html>，导致整页翻译失效

### DIFF
--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -489,18 +489,34 @@
       /np\.\w+/,                     // NumPy
     ];
 
-    // 代码高亮容器的 class 检测：按【完整 class token】匹配 highlight / highlighter
-    // 及其 - 连接的变体（highlight、highlight-source-js、highlighter-rouge、js-highlight）。
-    // 不能用 [class*="highlight"] 子串匹配：营销站常用 highlights/highlighted 命名普通
-    // 内容区块——如 retellai.com 用 <section class="c-home-highlights-accordion-2"> 包住
-    // 整篇博客正文，子串命中会把整篇正文当成代码块跳过，整页翻译对正文完全不生效。
+    // 代码块容器的 class 检测。全部按【完整 class token】匹配，绝不用 [class*=] 子串匹配：
+    //
+    // - highlight / highlighter 及其 - 连接的变体（highlight、highlight-source-js、
+    //   highlighter-rouge、js-highlight）。营销站常用 highlights/highlighted 命名普通
+    //   内容区块——如 retellai.com 用 <section class="c-home-highlights-accordion-2"> 包住
+    //   整篇博客正文，子串命中会把整篇正文当成代码块跳过，整页翻译对正文完全不生效。
+    //
+    // - Prism 的 language-<lang>。这条尤其危险：原来写成 [class*="language-"]，而
+    //   Wikipedia 的 Vector 2022 皮肤在 <html> 上挂了 vector-feature-language-in-header-enabled，
+    //   子串命中的是 <html>，于是 processElement(document.body) 第一步就 return，
+    //   整页一个块都收不到 → 误报“页面已翻译”，全文翻译对所有维基页面彻底失效。
+    //   只按 token 前缀匹配仍然不够：language-switcher / language-list / language-item
+    //   是多语言站导航的常见命名。所以还要求这个祖先真的装着代码（自身是 <pre>/<code>
+    //   或子孙里有），语言切换器不可能满足。
     const highlightClassTokenRe = /(^|-)highlight(er)?(-|$)/;
-    function isInsideCodeHighlightContainer(element) {
+    const CODE_CONTAINER_CLASSES = new Set(['codehilite', 'sourceCode', 'code-block']);
+    function holdsCode(el) {
+      const tagName = el.tagName;
+      return tagName === 'PRE' || tagName === 'CODE' || !!el.querySelector('pre, code');
+    }
+    function isInsideCodeContainer(element) {
       for (let el = element; el; el = el.parentElement) {
         const classList = el.classList;
         if (!classList) continue;
         for (const cls of classList) {
           if (highlightClassTokenRe.test(cls)) return true;
+          if (CODE_CONTAINER_CLASSES.has(cls)) return true;
+          if (cls.startsWith('language-') && holdsCode(el)) return true;
         }
       }
       return false;
@@ -632,9 +648,9 @@
       // 跳过被 skipTags 包含的元素
       if (element.closest(skipTags.map(t => t.toLowerCase()).join(','))) return;
 
-      // 跳过代码块容器（highlight 类及其变体在 isInsideCodeHighlightContainer 里按 token 匹配）
-      if (element.closest('.codehilite, .sourceCode, .code-block, [class*="language-"]')) return;
-      if (isInsideCodeHighlightContainer(element)) return;
+      // 跳过代码块容器（codehilite / sourceCode / highlight 变体 / Prism language-*，
+      // 统一在 isInsideCodeContainer 里按完整 class token 匹配）
+      if (isInsideCodeContainer(element)) return;
 
       // 跳过数学公式内部的所有元素 - 数学公式应该整体保留，不单独翻译内部元素
       if (element.closest(MATH_CONTAINER_SELECTOR)) return;

--- a/test/e2e/page-translation-highlight-class.spec.js
+++ b/test/e2e/page-translation-highlight-class.spec.js
@@ -2,23 +2,32 @@ const { test, expect } = require('./fixtures');
 const { setExtensionSettings, triggerPageTranslation } = require('./helpers');
 const { startMockOpenAIServer } = require('./mock-openai-server');
 
-// Regression test for the "code highlight container" skip rule in
-// collectTranslatableBlocks (content/content-page-translation.js).
+// Regression test for the "code container" skip rule in collectTranslatableBlocks
+// (content/content-page-translation.js).
 //
-// The rule used to match ancestors with `[class*="highlight"]`. Marketing sites
-// commonly name ordinary content sections with "highlights"/"highlighted" — e.g.
-// retellai.com wraps every blog article in <section class="c-home-highlights-accordion-2">
-// — so the substring match classified the whole article as a syntax-highlighted code
-// block and page translation silently skipped all of it (only nav/footer links were
-// translated). The rule must instead match complete class tokens (highlight,
-// highlighter-rouge, highlight-source-js, ...), which this spec pins down from both
-// directions: prose inside a "highlights" section is translated, prose inside real
-// highlighter containers is still skipped.
+// The rule used to match ancestors by class SUBSTRING, which misfired twice:
+//
+//   [class*="highlight"] — marketing sites commonly name ordinary content sections
+//   "highlights"/"highlighted"; retellai.com wraps every blog article in
+//   <section class="c-home-highlights-accordion-2">, so the whole article was
+//   classified as syntax-highlighted code and silently skipped (only nav/footer
+//   links got translated).
+//
+//   [class*="language-"] — Wikipedia's Vector 2022 skin puts
+//   vector-feature-language-in-header-enabled on <html>, so the substring matched
+//   the ROOT element. processElement(document.body) then returned on its first
+//   line, the page yielded zero blocks, and full-page translation reported
+//   "page already translated" on every Wikipedia article.
+//
+// Both must match complete class tokens instead, and language-* additionally
+// requires the ancestor to actually hold code (a <pre>/<code>) so that
+// language-switcher / language-list navigation is never mistaken for a code block.
+// This spec pins all of that down from both directions.
 //
 // The skipped-container probes deliberately contain plain prose, NOT code-looking
 // text: code-looking text would also be dropped by the looksLikeCode() heuristics,
 // and the test would then pass even if the class rule were deleted outright.
-test('page translation: "highlights" sections translate, real highlighter containers stay skipped', async ({ page }) => {
+test('page translation: "highlights"/"language-" lookalikes translate, real code containers stay skipped', async ({ page }) => {
   const { server, endpoint, fastBatchRequests } = await startMockOpenAIServer();
 
   try {
@@ -34,6 +43,10 @@ test('page translation: "highlights" sections translate, real highlighter contai
     await page.waitForSelector('#ai-translator-float-ball');
 
     await page.evaluate(() => {
+      // Wikipedia's real <html> class. Nothing below it is a code block, so the whole
+      // fixture is unreachable if the language- rule matches by substring on the root.
+      document.documentElement.classList.add('vector-feature-language-in-header-enabled');
+
       const container = document.createElement('div');
       container.id = 'highlight-class-test';
       container.innerHTML = `
@@ -42,6 +55,9 @@ test('page translation: "highlights" sections translate, real highlighter contai
             <p id="highlights-para">Benchmarking voice models on real customer conversations takes careful work.</p>
           </div>
         </section>
+        <div id="lang-switcher" class="language-switcher">
+          <p id="lang-switcher-para">Read this encyclopedia article in another language.</p>
+        </div>
         <div id="pygments-container" class="highlight">
           <p id="pygments-para">Plain sentence standing in for pygments highlighted source.</p>
         </div>
@@ -50,6 +66,10 @@ test('page translation: "highlights" sections translate, real highlighter contai
         </div>
         <div id="github-container" class="highlight-source-js">
           <p id="github-para">Plain sentence standing in for github highlighted source.</p>
+        </div>
+        <div id="prism-container" class="language-js">
+          <p id="prism-para">Plain sentence standing beside the prism highlighted source.</p>
+          <pre><code>x</code></pre>
         </div>
       `;
       document.body.appendChild(container);
@@ -66,24 +86,33 @@ test('page translation: "highlights" sections translate, real highlighter contai
       })
       .toBeGreaterThan(0);
 
-    // The article paragraph inside the "highlights" section must be translated.
-    await page.waitForFunction(() => {
-      const el = document.getElementById('highlights-para');
-      return el && el.classList.contains('ai-translator-translated');
-    });
+    // Prose inside the "highlights" section and inside the language switcher must be
+    // translated — neither is a code block, whatever their class names look like.
+    for (const id of ['highlights-para', 'lang-switcher-para']) {
+      await page.waitForFunction(
+        (paraId) => {
+          const el = document.getElementById(paraId);
+          return el && el.classList.contains('ai-translator-translated');
+        },
+        id,
+        { timeout: 30000 }
+      );
+    }
     await expect(page.locator('#highlights-section .ai-translator-inline-block')).toHaveCount(1);
     await expect(page.locator('#highlights-section .ai-translator-inline-block')).toContainText('[T]');
+    await expect(page.locator('#lang-switcher .ai-translator-inline-block')).toHaveCount(1);
 
     // Wait until the whole run settles (progress bar auto-removes on completion) so the
     // negative assertions below mean "never translated", not "not translated yet".
     await page.waitForSelector('#ai-translator-progress', { state: 'hidden', timeout: 30000 });
 
-    for (const id of ['pygments-para', 'rouge-para', 'github-para']) {
+    for (const id of ['pygments-para', 'rouge-para', 'github-para', 'prism-para']) {
       await expect(page.locator(`#${id}`)).not.toHaveClass(/ai-translator-translated/);
     }
     await expect(page.locator('#pygments-container .ai-translator-inline-block')).toHaveCount(0);
     await expect(page.locator('#rouge-container .ai-translator-inline-block')).toHaveCount(0);
     await expect(page.locator('#github-container .ai-translator-inline-block')).toHaveCount(0);
+    await expect(page.locator('#prism-container .ai-translator-inline-block')).toHaveCount(0);
   } finally {
     server.close();
   }


### PR DESCRIPTION
## 根因

全文翻译在**所有 Wikipedia 页面**上完全失效（点击后无反应，提示“页面已翻译”，一次 API 请求都不会发出）。

`collectTranslatableBlocks` 的代码块跳过规则用了子串匹配：

```js
if (element.closest('.codehilite, .sourceCode, .code-block, [class*="language-"]')) return;
```

Wikipedia 的 Vector 2022 皮肤在 **`<html>`** 上挂了这几个 class：

- `vector-feature-language-in-header-enabled`
- `vector-feature-language-in-main-menu-disabled`
- `vector-feature-language-in-main-page-header-disabled`

`[class*="language-"]` 是子串匹配，于是 `document.body.closest(...)` 命中的是根元素 `<html>`。
`processElement(document.body)` 第一步就 `return`，整页收不到任何可译块 →
`translatableBlocks.length === 0` → 置 `pageHasBeenTranslated = true` 并提示“页面已翻译”。

这与之前修过的 `[class*="highlight"]` 是同一类 bug（营销站 `c-home-highlights-accordion-2`
包住整篇正文），当时只修了 `highlight` 一条，`language-` 这条留了下来。

## 改动

把两条祖先规则合并成一次遍历 `isInsideCodeContainer()`，**全部按完整 class token 匹配**：

- `highlight` / `highlighter` 及其 `-` 连接变体（沿用原有 token 正则）
- `codehilite` / `sourceCode` / `code-block`（精确 token）
- Prism 的 `language-<lang>`：**仅按 token 前缀匹配还不够** —— `language-switcher`、
  `language-list`、`language-item` 是多语言站导航的常见命名。所以额外要求该祖先真的装着代码
  （自身是 `<pre>`/`<code>`，或子孙里有），语言切换器不可能满足这个条件。

## 验证

- 在真实的 `https://simple.wikipedia.org/wiki/Adele` DOM 上验证：修复前 `document.body` 即被跳过；
  修复后 body 不再被跳过，正文 176 个块全部可收集。
- 扩展了回归用例 `test/e2e/page-translation-highlight-class.spec.js`：
  - `<html class="vector-feature-language-in-header-enabled">`（Wikipedia 真实 class）
  - `language-switcher` 导航里的正文**必须**被翻译
  - `language-js` + 内含 `<pre><code>` 的真实 Prism 容器**仍然**被跳过
  - 已确认该用例在旧规则下失败（0 次 API 请求，与线上症状一致），修复后通过
- `npm test` 全绿：156 unit + 117 e2e 通过，9 skipped（原有的依赖网络的用例）
