### PR TITLE
fix(page-translation): arXiv/LaTeXML 论文的代码清单被逐 token 送去翻译

### DIFF
--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -503,8 +503,20 @@
     //   只按 token 前缀匹配仍然不够：language-switcher / language-list / language-item
     //   是多语言站导航的常见命名。所以还要求这个祖先真的装着代码（自身是 <pre>/<code>
     //   或子孙里有），语言切换器不可能满足。
+    //
+    // - LaTeXML 的 ltx_listing / ltx_lstlisting / ltx_listingline / ltx_verbatim
+    //   （arXiv HTML 版与 ar5iv 论文的代码清单）。这条必须单列，上面两条都够不着它：
+    //   LaTeXML 把语种写成 ltx_lst_language_Python，是【下划线】，language- 匹配不到；
+    //   而清单里根本没有 <pre>/<code>——结构是
+    //   <div class="ltx_listing"><div class="ltx_listingline"><span class="ltx_text …">，
+    //   于是每个 <span> 都作为内联可译元素被单独送去翻译（实测泄漏 qa / dspy / Predict /
+    //   "question->answer" / # Out: Prediction(...)）。looksLikeCode() 也接不住：
+    //   拆到单个 span 之后碎片里一个特殊字符都没有。
     const highlightClassTokenRe = /(^|-)highlight(er)?(-|$)/;
-    const CODE_CONTAINER_CLASSES = new Set(['codehilite', 'sourceCode', 'code-block']);
+    const CODE_CONTAINER_CLASSES = new Set([
+      'codehilite', 'sourceCode', 'code-block',
+      'ltx_listing', 'ltx_lstlisting', 'ltx_listingline', 'ltx_verbatim',
+    ]);
     function holdsCode(el) {
       const tagName = el.tagName;
       return tagName === 'PRE' || tagName === 'CODE' || !!el.querySelector('pre, code');

--- a/test/e2e/mock-openai-server.js
+++ b/test/e2e/mock-openai-server.js
@@ -20,6 +20,11 @@ function startMockOpenAIServer() {
   // One entry per request that took the fast-batch path, so tests can assert the mock
   // really spoke the delimiter protocol rather than falling through to the single-text path.
   const fastBatchRequests = [];
+  // The raw user-message text of EVERY request, whichever path it took. A "this text must
+  // never be translated" assertion has to check what actually left the browser: asserting on
+  // the DOM instead only proves no translation was rendered, which also passes when the text
+  // was shipped to the API and the reply merely failed to land.
+  const sentTexts = [];
 
   return new Promise((resolve) => {
     const server = http.createServer((req, res) => {
@@ -45,6 +50,8 @@ function startMockOpenAIServer() {
           content = '';
         }
 
+        if (content) sentTexts.push(content);
+
         const delimiter = systemPrompt.match(PROMPT_DELIMITER_RE)?.[1];
         if (delimiter) {
           const segments = content.split(delimiter);
@@ -69,6 +76,7 @@ function startMockOpenAIServer() {
       resolve({
         server,
         fastBatchRequests,
+        sentTexts,
         endpoint: `http://127.0.0.1:${port}/v1/chat/completions`
       });
     });

--- a/test/e2e/page-translation-paper-listing.spec.js
+++ b/test/e2e/page-translation-paper-listing.spec.js
@@ -1,0 +1,110 @@
+const { test, expect } = require('./fixtures');
+const { setExtensionSettings, triggerPageTranslation } = require('./helpers');
+const { startMockOpenAIServer } = require('./mock-openai-server');
+
+// Regression test for LaTeXML code listings (arXiv HTML papers, ar5iv) in
+// collectTranslatableBlocks (content/content-page-translation.js).
+//
+// The code-container skip rule never reached these, for two independent reasons:
+//
+//   1. LaTeXML writes the language as ltx_lst_language_Python — an UNDERSCORE — so
+//      neither the old [class*="language-"] substring rule nor the token rule that
+//      replaced it can see it.
+//   2. There is no <pre> or <code> anywhere in the listing, so the skipTags guard
+//      does not fire either. The structure is
+//        <div class="ltx_listing"><div class="ltx_listingline"><span class="ltx_text …">
+//      and every one of those spans is an inline translatable element, so the source
+//      was shipped to the API one token at a time: "qa", "dspy", "Predict",
+//      '"question->answer"', "# Out: Prediction(...)".
+//
+// looksLikeCode() cannot be the backstop here: once the line is split across spans the
+// fragments carry no special characters at all ("qa", "dspy") and read as ordinary words.
+// So the listing container classes have to be recognized explicitly.
+//
+// The markup below is copied from a real paper (arxiv.org/html/2310.03714v1, DSPy),
+// only with the base64 <div class="ltx_listing_data"> download blob stripped.
+const ARXIV_LISTING = `
+<div id="S3.SS1.p4.1" class="ltx_listing ltx_lst_language_Python ltx_lst_numbers_left ltx_lstlisting ltx_listing">
+  <div id="lstnumberx1" class="ltx_listingline">
+    <span class="ltx_tag ltx_tag_listingline">1</span>
+    <span class="ltx_text ltx_lst_identifier ltx_font_typewriter">qa</span><span class="ltx_text ltx_lst_space ltx_font_typewriter"> </span><span class="ltx_text ltx_font_typewriter">=</span><span class="ltx_text ltx_lst_space ltx_font_typewriter"> </span><span class="ltx_text ltx_lst_emph ltx_font_typewriter">dspy</span><span class="ltx_text ltx_font_typewriter">.</span><span class="ltx_text ltx_lst_identifier ltx_font_typewriter">Predict</span><span class="ltx_text ltx_font_typewriter">(</span><span class="ltx_text ltx_lst_string ltx_font_typewriter">"question<span class="ltx_text ltx_lst_space"> </span>-&gt;<span class="ltx_text ltx_lst_space"> </span>answer"</span><span class="ltx_text ltx_font_typewriter">)</span>
+  </div>
+  <div id="lstnumberx3" class="ltx_listingline">
+    <span class="ltx_tag ltx_tag_listingline">3</span>
+    <span class="ltx_text ltx_lst_comment ltx_font_typewriter"># Out: Prediction(answer='Guarani is spoken mainly in South America.')</span>
+  </div>
+</div>
+`;
+
+test('page translation: arXiv/LaTeXML code listings never reach the API, paper prose still does', async ({ page }) => {
+  const { server, endpoint, fastBatchRequests, sentTexts } = await startMockOpenAIServer();
+
+  try {
+    await setExtensionSettings(page, {
+      apiEndpoint: endpoint,
+      apiKey: 'test-key',
+      modelName: 'gpt-4.1-mini',
+      targetLang: 'zh-CN',
+      autoDetect: false
+    });
+
+    await page.goto('https://example.com');
+    await page.waitForSelector('#ai-translator-float-ball');
+
+    await page.evaluate((listing) => {
+      const container = document.createElement('div');
+      container.id = 'paper-listing-test';
+      container.innerHTML = `
+        <article class="ltx_document">
+          <section class="ltx_section">
+            <p id="paper-prose" class="ltx_p">We introduce a programming model that abstracts language model pipelines.</p>
+            ${listing}
+            <figcaption id="paper-caption" class="ltx_caption">Figure 1: A minimal question answering program.</figcaption>
+          </section>
+        </article>
+      `;
+      document.body.appendChild(container);
+    }, ARXIV_LISTING);
+
+    await triggerPageTranslation(page);
+
+    // Fail fast if the prompt wording drifted and the mock could no longer recover the
+    // delimiter; the symptom would otherwise be an unexplained timeout on the wait below.
+    await expect
+      .poll(() => fastBatchRequests.length, {
+        timeout: 15000,
+        message: 'mock never recognized a fast-batch request (delimiter not found in system prompt)'
+      })
+      .toBeGreaterThan(0);
+
+    // The paper's own prose and its figure caption must still be translated — the listing
+    // rule must not swallow the surrounding article.
+    for (const id of ['paper-prose', 'paper-caption']) {
+      await page.waitForFunction(
+        (proseId) => {
+          const el = document.getElementById(proseId);
+          return el && el.classList.contains('ai-translator-translated');
+        },
+        id,
+        { timeout: 30000 }
+      );
+    }
+
+    // Let the run settle so the assertions below mean "never sent", not "not sent yet".
+    await page.waitForSelector('#ai-translator-progress', { state: 'hidden', timeout: 30000 });
+
+    // Assert on what actually left the browser. Checking the DOM instead would also pass
+    // if the source had been shipped and the reply merely failed to render.
+    const outbound = sentTexts.join('\n');
+    expect(outbound).toContain('programming model that abstracts');
+    for (const fragment of ['dspy', 'Predict', 'question->answer', "Prediction(answer='"]) {
+      expect(outbound, `listing source "${fragment}" was sent to the translation API`).not.toContain(fragment);
+    }
+
+    // And nothing inside the listing may be rendered as a translation.
+    await expect(page.locator('#S3\\.SS1\\.p4\\.1 .ai-translator-inline-block')).toHaveCount(0);
+    await expect(page.locator('#S3\\.SS1\\.p4\\.1 .ai-translator-translated')).toHaveCount(0);
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
## 根因

arXiv HTML 版 / ar5iv 论文的**代码清单会被逐个 token 送去翻译**。实测从真实论文
（arxiv.org/html/2310.03714v1, DSPy）泄漏到翻译 API 的内容：

```
[4] qa   [5] dspy   [6] Predict   [7] "question->answer"
[8] # Out: Prediction(answer='Guarani is spoken mainly in South America.')
```

`collectTranslatableBlocks` 里的代码块跳过规则够不着它，两个独立原因：

1. LaTeXML 把语种写成 `ltx_lst_language_Python` —— **下划线**。无论是之前的
   `[class*="language-"]` 子串规则，还是 #50 换上的 token 规则，都匹配不到。
2. 清单里**根本没有 `<pre>`/`<code>`**，所以 `skipTags` 那道防线也不触发。结构是：

   ```html
   <div class="ltx_listing ltx_lst_language_Python">
     <div class="ltx_listingline">
       <span class="ltx_text ltx_lst_identifier">qa</span>…
   ```

   每个 `<span>` 都是内联可译元素，于是源码被一个 token 一个 token 地送出去。

`looksLikeCode()` 接不住：拆到单个 span 之后，碎片（`qa`、`dspy`）一个特殊字符都没有，
读起来就是普通单词。所以清单容器的 class 必须显式识别。

> 注：这是**既有** bug，不是 #50 引入的。已用旧规则复跑同一探针验证，出站 payload
> 与新规则**逐字节相同**——#50 对论文站是 no-op（那条规则在整个 arXiv 页面匹配到 0 个元素）。

## 改动

把 LaTeXML 的清单容器加进 #50 建立的那份 code-container token 集合：
`ltx_listing` / `ltx_lstlisting` / `ltx_listingline` / `ltx_verbatim`。

仍然是**完整 class token 精确匹配**，不引入任何子串匹配。

## 验证

在**真实**的 DSPy 论文页面上跑逐元素探针：

| 指标 | 结果 |
| --- | --- |
| 考察块数 | 4592 |
| 新规则跳过 | 970（= 230 行清单 × 每行若干 span） |
| 跳过样本 | `qa`、`dspy`、`Predict`、`"question -> answer"` |
| 论文真实段落 | 81 |
| **被误跳的真实段落** | **0** |

顺带减少约 21% 的出站块数，也省 API 费用。

新增回归用例 `test/e2e/page-translation-paper-listing.spec.js`，markup 直接取自真实论文
（只去掉 base64 下载 blob）：

- 论文正文段落和 figure caption **必须**照常翻译（防止规则吞掉整篇文章）
- 清单里的源码**不得**出现在任何出站请求里
- 已确认该用例在修复前失败，报错即 `listing source "dspy" was sent to the translation API`

断言直接检查**离开浏览器的字节**（新增 `sentTexts`），而不是查 DOM —— 查 DOM 的话，
"源码送出去了但回包没渲染上"也会被判为通过。

`npm test` 全绿：156 unit + 118 e2e，9 skipped（原有的依赖网络用例）。
