### PR TITLE
fix(css): a theme's `.kit button:hover` still reached our controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,21 @@ No build step required - the extension loads directly in Chrome as an unpacked e
 - **Theming**: CSS variables for dark/light theme support
 - **Host-page containment**: our panels are a subtree of the page's own
   document, so every page rule on a bare tag matches them too — example.com
-  ships `div { opacity: .8 }`. One scoped reset at the top of
-  `content/content.css` is the boundary; **a new panel root has to be added to
-  its `:is()` lists**, and its own rules have to outrank (0,1,0). Guarded by
-  `test/unit/host-css-containment.test.mjs` and the hostile-stylesheet spec in
-  `test/e2e/input-translation.spec.js`.
+  ships `div { opacity: .8 }`, and every page builder ships
+  `.kit button { … }` plus a heavier `.kit button:hover` twin. One scoped reset
+  at the top of `content/content.css` is the boundary, and specificity is a
+  four-step band with no `!important` in it:
+
+  ```
+  theme base (0,1,1) < theme state (0,2,1) < the reset (0,2,2) ≤ ours (0,2,2)
+  ```
+
+  So **a new panel root has to be added to the reset's `:is()` lists**, and a
+  new rule for a control needs `html body` plus its panel root
+  (`html[data-ai-translator-theme="light"] body …` for a light override) or the
+  theme's `:hover` takes back every property the rule leaves to the base rule.
+  Guarded by `test/unit/host-css-containment.test.mjs` and the
+  hostile-stylesheet spec in `test/e2e/input-translation.spec.js`.
 
 ### Account-Backed Features
 

--- a/content/content.css
+++ b/content/content.css
@@ -135,20 +135,40 @@
    Elementor is on a large slice of the web and every page builder ships the
    same shape, so this is the common case, not one hostile site.
 
-   The specificity here is the whole point, and it sits in a band:
+   The same kit ships a second rule that has to be answered separately:
 
-   - `body` in front adds a type selector, so this weighs (0,1,2) and beats the
-     (0,1,1) theme rule outright. A tie would be settled by source order, and
-     the page's stylesheet is parsed after ours injects, so a tie loses.
-   - It stays one class short of (0,2,0), which is what our own control rules
-     below now weigh — they carry their panel root as a prefix for exactly this
-     reason. So this neutralises the theme and then our own design wins back
-     every property it declares, without an `!important` anywhere.
+     .elementor-kit-6 button:hover,
+     .elementor-kit-6 button:focus { background: #000216; color: #fff;
+                                     border: 1px solid #000216 }
+
+   That weighs (0,2,1) — a whole class heavier, because a state is a
+   pseudo-class. It reaches every property the hovered control's *own* hover
+   rule does not restate, and there are always some: the float menu's items
+   set `border: none` and their colour in the base rule only, so hovering one
+   drew a 1px near-black box around it and flipped the label to #fff, which on
+   the light theme is white on white. Themes animate `transform` on hover as
+   often as they recolour, and no control of ours declares that at all.
+
+   So the band has four steps, and no `!important` anywhere in it:
+
+     theme base (0,1,1) < theme state (0,2,1) < this reset (0,2,2) ≤ ours (0,2,2)
+
+   - `body` in front adds a type selector and `:is(:enabled, :disabled)` adds
+     the class. The union is every form control in every state, so it changes
+     nothing about what this matches — it is here for the one class of weight,
+     which is what puts the reset above a theme's `:hover` as well as its base
+     rule.
+   - Our own control rules carry `html body` and their panel root, which lands
+     them on (0,2,2) too. A tie inside one stylesheet is settled by source
+     order and they all sit below this block, so they win back every property
+     they declare and this reset keeps the rest. A tie with the *page* would
+     go the other way — its sheet parses after ours injects — which is why
+     beating the theme has to be strict.
 
    Adding a control to a panel needs nothing here; adding a *rule* for one
-   needs the root prefix, or the theme takes it back. That is asserted by
-   test/unit/host-css-containment.test.mjs. */
-body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-translator-float-menu"], [id="ai-translator-float-ball"], [id="ai-translator-float-ball-container"], [id="ai-translator-progress"], [id="ai-translator-selection-btn"], [id="ai-translator-caption-overlay"]) :is(button, input, textarea, select) {
+   needs the `html body` + root prefix, or the theme's hover takes it back.
+   That is asserted by test/unit/host-css-containment.test.mjs. */
+body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-translator-float-menu"], [id="ai-translator-float-ball"], [id="ai-translator-float-ball-container"], [id="ai-translator-progress"], [id="ai-translator-selection-btn"], [id="ai-translator-caption-overlay"]) :is(button, input, textarea, select):is(:enabled, :disabled) {
   box-sizing: border-box;
   appearance: none;
   background: transparent;
@@ -240,7 +260,7 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
   color: var(--text-primary);
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-close {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-close {
   width: 28px;
   height: 28px;
   display: flex;
@@ -255,7 +275,7 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
   transition: all 0.2s ease;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-close:hover {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-close:hover {
   background: var(--icon-hover-bg);
   border-color: var(--icon-hover-border);
   color: var(--text-primary);
@@ -288,7 +308,7 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
   position: relative;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-trigger {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-trigger {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -307,11 +327,11 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
   transition: all 0.2s ease;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-trigger:hover {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-trigger:hover {
   border-color: var(--accent);
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-trigger:focus {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-trigger:focus {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 2px rgba(111, 99, 255, 0.15);
@@ -347,7 +367,7 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
   overflow-y: auto;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-item {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-item {
   width: 100%;
   text-align: left;
   border: none;
@@ -359,11 +379,11 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
   cursor: pointer;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-item:hover {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-item:hover {
   background: var(--icon-hover-bg);
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-item.is-selected {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-lang-item.is-selected {
   background: rgba(111, 99, 255, 0.18);
   color: var(--text-primary);
 }
@@ -377,7 +397,7 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
   overflow-y: auto;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-icon-btn {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-icon-btn {
   width: 28px;
   height: 28px;
   display: inline-flex;
@@ -391,13 +411,13 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
   transition: all 0.2s ease;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-icon-btn:hover {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-icon-btn:hover {
   background: var(--icon-hover-bg);
   border-color: var(--icon-hover-border);
   color: var(--accent);
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-icon-btn:focus-visible {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-icon-btn:focus-visible {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 2px rgba(111, 99, 255, 0.25);
@@ -405,7 +425,7 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
 
 /* A speaker button that is mid-utterance is also its own stop button, so it
    has to look engaged rather than merely hovered. */
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-icon-btn.is-speaking {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-icon-btn.is-speaking {
   background: var(--icon-hover-bg);
   border-color: var(--icon-hover-border);
 }
@@ -561,7 +581,7 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
   border-top: 1px solid var(--divider);
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-btn {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -576,7 +596,7 @@ body :is(.ai-translator-popup, [id="ai-translator-input-dialog"], [id="ai-transl
   transition: all 0.2s ease;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-btn:hover {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-btn:hover {
   background: var(--btn-hover-bg);
   color: var(--text-primary);
   border-color: var(--accent);
@@ -845,7 +865,7 @@ button.ai-translator-inline-block {
   color: #22c55e;
 }
 
-[id="ai-translator-progress"] .ai-translator-progress-close {
+html body [id="ai-translator-progress"] .ai-translator-progress-close {
   width: 28px;
   height: 28px;
   flex-shrink: 0;
@@ -863,7 +883,7 @@ button.ai-translator-inline-block {
   z-index: 10;
 }
 
-[id="ai-translator-progress"] .ai-translator-progress-close:hover {
+html body [id="ai-translator-progress"] .ai-translator-progress-close:hover {
   background: linear-gradient(145deg, #4a2525 0%, #3a1a1a 100%);
   border-color: rgba(239, 68, 68, 0.5);
   color: #f87171;
@@ -871,7 +891,7 @@ button.ai-translator-inline-block {
   box-shadow: 0 0 12px rgba(239, 68, 68, 0.3);
 }
 
-[id="ai-translator-progress"] .ai-translator-progress-close:active {
+html body [id="ai-translator-progress"] .ai-translator-progress-close:active {
   transform: scale(0.95);
 }
 
@@ -1243,7 +1263,7 @@ button.ai-translator-inline-block {
   }
 }
 
-[id="ai-translator-float-menu"] .ai-translator-menu-item {
+html body [id="ai-translator-float-menu"] .ai-translator-menu-item {
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -1262,11 +1282,11 @@ button.ai-translator-inline-block {
   box-sizing: border-box;
 }
 
-[id="ai-translator-float-menu"] .ai-translator-menu-item:hover {
+html body [id="ai-translator-float-menu"] .ai-translator-menu-item:hover {
   background: rgba(124, 92, 255, 0.15);
 }
 
-[id="ai-translator-float-menu"] .ai-translator-menu-item:active {
+html body [id="ai-translator-float-menu"] .ai-translator-menu-item:active {
   background: rgba(124, 92, 255, 0.25);
 }
 
@@ -1381,7 +1401,7 @@ button.ai-translator-inline-block {
   gap: 8px;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-textarea {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-textarea {
   width: 100%;
   padding: 12px 14px;
   background: var(--pill-bg);
@@ -1396,13 +1416,13 @@ button.ai-translator-inline-block {
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-textarea:focus {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-textarea:focus {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 3px rgba(111, 99, 255, 0.2);
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-textarea::placeholder {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-textarea::placeholder {
   color: var(--text-muted);
 }
 
@@ -1424,18 +1444,18 @@ button.ai-translator-inline-block {
 
 /* Copy sits opposite the primary action instead of trailing the result panel,
    so the two things you can do with a translation share one row. */
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-btn-copy {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-btn-copy {
   margin-right: auto;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-btn-primary {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-btn-primary {
   background: var(--accent);
   border-color: var(--accent);
   color: #fff;
   box-shadow: 0 6px 16px rgba(111, 99, 255, 0.3);
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-btn-primary:hover {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-btn-primary:hover {
   background: #7c72ff;
 }
 
@@ -1464,8 +1484,8 @@ button.ai-translator-inline-block {
   white-space: nowrap;
 }
 
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-speak,
-:is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-speak-result {
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-speak,
+html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-input-speak-result {
   flex-shrink: 0;
 }
 
@@ -1508,7 +1528,7 @@ button.ai-translator-inline-block {
   box-shadow: 0 16px 36px rgba(15, 23, 42, 0.12);
 }
 
-[data-ai-translator-theme="light"] .ai-translator-lang-item.is-selected {
+html[data-ai-translator-theme="light"] body .ai-translator-lang-item.is-selected {
   background: rgba(111, 99, 255, 0.12);
 }
 
@@ -1544,13 +1564,13 @@ button.ai-translator-inline-block {
   color: #16a34a;
 }
 
-[data-ai-translator-theme="light"] .ai-translator-progress-close {
+html[data-ai-translator-theme="light"] body .ai-translator-progress-close {
   background: linear-gradient(145deg, #fef2f2 0%, #fee2e2 100%);
   border-color: rgba(239, 68, 68, 0.2);
   color: #dc2626;
 }
 
-[data-ai-translator-theme="light"] .ai-translator-progress-close:hover {
+html[data-ai-translator-theme="light"] body .ai-translator-progress-close:hover {
   background: linear-gradient(145deg, #fee2e2 0%, #fecaca 100%);
   border-color: rgba(239, 68, 68, 0.4);
   color: #b91c1c;
@@ -1626,11 +1646,11 @@ button.ai-translator-inline-block {
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12), 0 0 0 1px rgba(124, 92, 255, 0.1);
 }
 
-[data-ai-translator-theme="light"] .ai-translator-menu-item {
+html[data-ai-translator-theme="light"] body .ai-translator-menu-item {
   color: #1d1d1f;
 }
 
-[data-ai-translator-theme="light"] .ai-translator-menu-item:hover {
+html[data-ai-translator-theme="light"] body .ai-translator-menu-item:hover {
   background: rgba(124, 92, 255, 0.08);
 }
 

--- a/test/e2e/input-translation.spec.js
+++ b/test/e2e/input-translation.spec.js
@@ -128,6 +128,13 @@ test('input translation shows phonetic for words and read-aloud for anything typ
  * Elementor's kit rule copied off azulle.com, where it turned the float menu,
  * the popup, the input dialog and the progress toast into stacks of lime pills
  * all at once.
+ *
+ * Its `:hover`/`:focus` twin is the fifth, and it is heavier still — a state is
+ * a pseudo-class, so (0,2,1). It takes whatever the control's own hover rule
+ * does not restate, which on the first fix was the border and the colour: the
+ * float menu drew a near-black box around the item under the pointer and turned
+ * its label white, on a white menu. Both rules are the real values off that
+ * site, so the fixture fails the way the site did.
  */
 const HOSTILE_PAGE_CSS = `
   div { opacity: 0.8; box-sizing: content-box; filter: saturate(0.4); }
@@ -141,6 +148,12 @@ const HOSTILE_PAGE_CSS = `
     border-radius: 100px;
     padding: 14px 30px;
     font: 600 15.75px monospace;
+  }
+  .host-kit button:hover,
+  .host-kit button:focus {
+    background-color: rgb(0, 2, 22);
+    color: rgb(255, 255, 255);
+    border: 1px solid rgb(0, 2, 22);
   }
 `;
 
@@ -338,6 +351,19 @@ function computed(page, selector, properties) {
   }, { sel: selector, props: properties });
 }
 
+/**
+ * Wait out a hover/focus transition on one element.
+ *
+ * The menu item carries `transition: background 0.15s`, so a computed style read
+ * taken the instant after `page.hover()` samples the first frame — rgba(0, 0, 0, 0)
+ * on its way to our purple, which reads exactly like the rule never matched.
+ */
+function settleTransitions(page, selector) {
+  return page.evaluate((sel) => Promise.all(
+    document.querySelector(sel).getAnimations().map((animation) => animation.finished.catch(() => {})),
+  ), selector);
+}
+
 test('a theme\'s button style cannot reach our controls', async ({ page }) => {
   // The reported symptom, on azulle.com: every panel rendered as a stack of
   // lime pills. `.host-kit button` weighs (0,1,1) and every control rule of
@@ -377,6 +403,20 @@ test('a theme\'s button style cannot reach our controls', async ({ page }) => {
     expect(item['font-weight']).toBe('400');
     expect(item['font-family']).not.toContain('monospace');
 
+    // Hovering is where the page gets a second, heavier go at it. Our own hover
+    // rule only sets a background, so the border and the colour have to come
+    // from the base rule outranking `.host-kit button:hover`, not from us
+    // restating them per control.
+    await page.hover('.ai-translator-menu-item[data-action="translate-page"]');
+    await settleTransitions(page, '.ai-translator-menu-item[data-action="translate-page"]');
+    const hovered = await computed(page, '.ai-translator-menu-item[data-action="translate-page"]', [
+      'background-color', 'color', 'border-top-width', 'border-top-style',
+    ]);
+    expect(hovered['background-color']).toBe('rgba(124, 92, 255, 0.08)');
+    expect(hovered.color).toBe('rgb(29, 29, 31)');
+    expect(hovered['border-top-width']).toBe('0px');
+    expect(hovered['border-top-style']).toBe('none');
+
     await page.click('.ai-translator-menu-item[data-action="translate-input"]');
     await page.waitForSelector('#ai-translator-input-dialog', { state: 'visible' });
     await settleDialogAnimations(page);
@@ -389,6 +429,14 @@ test('a theme\'s button style cannot reach our controls', async ({ page }) => {
     expect(primary['border-radius']).toBe('999px');
     expect(primary.padding).toBe('9px 14px');
     expect(primary['font-size']).toBe('14px');
+
+    // `:focus` is the state that outlives the pointer — a clicked button keeps
+    // it, so a leak here is not a flicker, it is how the button then looks.
+    await page.focus('#ai-translator-do-translate');
+    await settleTransitions(page, '#ai-translator-do-translate');
+    const focused = await computed(page, '#ai-translator-do-translate', ['background-color', 'color']);
+    expect(focused['background-color']).toBe('rgb(111, 99, 255)');
+    expect(focused.color).toBe('rgb(255, 255, 255)');
 
     const trigger = await computed(page, '#ai-translator-input-dialog .ai-translator-lang-trigger', [
       'border-radius', 'padding', 'font-weight',
@@ -562,3 +610,4 @@ test('the containment reset does not outrank our own fade-in', async ({ page }) 
     fixture.close();
   }
 });
+

--- a/test/unit/host-css-containment.test.mjs
+++ b/test/unit/host-css-containment.test.mjs
@@ -172,16 +172,25 @@ test('the reset is declared before the rules that have to beat it', () => {
 // popup, the input dialog and the progress toast all lost their background,
 // padding, border-radius and font to the page's button style at once.
 //
-// The fix is a specificity band, and both edges of it are asserted here
-// because a browser only shows you the failure on a site that happens to ship
-// the rule:
+// The same kit ships `.elementor-kit-6 button:hover`, and a state is a
+// pseudo-class, so that one weighs (0,2,1) — heavier again. It takes whatever
+// the control's own hover rule does not restate, which is why hovering a float
+// menu item drew a near-black 1px box around it and turned the label white.
 //
-//   theme (0,1,1)  <  the control reset (0,1,2)  <  our own rules (0,2,0)
+// So the fix is a four-step specificity band, and every edge of it is asserted
+// here because a browser only shows you the failure on a site that happens to
+// ship the rule:
 //
-// The reset gets its extra type selector from a leading `body`; our own rules
-// get their second class from the panel root they are scoped to. A new rule
-// for a control written the old way, with one class, silently drops back
-// underneath the theme — that is what the last test catches.
+//   theme (0,1,1)  <  theme state (0,2,1)  <  the reset (0,2,2)  ≤  ours (0,2,2)
+//
+// The reset gets there from a leading `body` plus `:is(:enabled, :disabled)`,
+// which matches every control in every state and is there for the class of
+// weight alone; our own rules get there from `html body` plus the panel root.
+// The last tie is settled by source order within our own stylesheet, so the
+// reset has to stay above them in the file — which the older guard above
+// already asserts. A new rule for a control written the old way, with one
+// class, silently drops back underneath the theme — that is what the last test
+// catches.
 
 /** Rough CSS specificity: [ids, classes, types]. `:is()`/`:not()` take the max of their arguments. */
 function specificity(selector) {
@@ -249,23 +258,27 @@ test('the markup still renders controls we have to defend', () => {
   assert.ok(classes.has('ai-translator-menu-item'), 'the float menu items are no longer buttons with that class');
 });
 
+/** A theme's `.kit button` and its `:hover`/`:focus` twin — the two weights to clear. */
+const THEME_BASE = [0, 1, 1];
+const THEME_STATE = [0, 2, 1];
+
 test('the control reset outranks a theme rule but not our own', () => {
   const reset = selectors(resetBlock()).filter((s) => /\b(button|textarea|select)\b/.test(s));
   assert.equal(reset.length, 1, 'expected exactly one form-control rule in the containment block');
   const weight = specificity(reset[0]);
   assert.ok(
-    compare(weight, [0, 1, 1]) > 0,
-    `the control reset weighs ${weight} and no longer beats a theme's \`.kit button\` (0,1,1); `
-    + 'the panels go back to the page\'s button style',
+    compare(weight, THEME_STATE) > 0,
+    `the control reset weighs ${weight} and no longer beats a theme's \`.kit button:hover\` (0,2,1); `
+    + 'a page that restyles or moves its buttons on hover reaches ours',
   );
   assert.ok(
-    compare(weight, [0, 2, 0]) < 0,
-    `the control reset weighs ${weight} and now outranks our own control rules (0,2,0); `
+    compare(weight, [0, 2, 2]) <= 0,
+    `the control reset weighs ${weight} and now outranks our own control rules (0,2,2); `
     + 'it would flatten every background, padding and radius we set',
   );
 });
 
-test('every rule for one of our controls is scoped to its panel root', () => {
+test('every rule for one of our controls outranks the theme, in every state', () => {
   const classes = controlClasses();
   const offenders = [];
   for (const selector of allSelectors()) {
@@ -275,13 +288,16 @@ test('every rule for one of our controls is scoped to its panel root', () => {
     // `!important` throughout is its own defence — .ai-translator-inline-block is a page
     // element, not a panel child, and cannot be scoped to a root.
     if (new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{[^{}]*!\\s*important`).test(CSS)) continue;
-    if (compare(specificity(selector), [0, 1, 1]) <= 0) offenders.push(selector);
+    if (compare(specificity(selector), THEME_STATE) <= 0) offenders.push(selector);
   }
   assert.deepEqual(
     offenders,
     [],
-    'these control rules weigh (0,1,0) and lose to a theme\'s `.kit button` (0,1,1).\n'
-    + 'Prefix each with the panel root it lives in, e.g.\n'
-    + '  :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-btn { … }',
+    `these control rules do not clear a theme's \`.kit button:hover\` (${THEME_STATE}), so the page\n`
+    + `takes every property they leave to the base rule — a rule at ${THEME_BASE} is not enough.\n`
+    + 'Prefix each with `html body` and the panel root it lives in, e.g.\n'
+    + '  html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-translator-btn { … }\n'
+    + 'A light-theme override takes the attribute onto the `html` it is already set on:\n'
+    + '  html[data-ai-translator-theme="light"] body .ai-translator-menu-item { … }',
   );
 });


### PR DESCRIPTION
## Background
- This PR packages the current branch changes for review.
- It groups the current branch updates into one reviewable change.

## Solution
- fix(css): a theme's `.kit button:hover` still reached our controls

## Affected Files
- `CLAUDE.md`
- `content/content.css`
- `test/e2e/input-translation.spec.js`
- `test/unit/host-css-containment.test.mjs`