### PR TITLE
fix(ocr): drop the lines Tesseract itself did not believe

### DIFF
--- a/offscreen/offscreen.js
+++ b/offscreen/offscreen.js
@@ -97,12 +97,52 @@
     }
   }
 
+  // The structured `blocks` output as paragraphs of {text, confidence} lines —
+  // the shape OCRCore.filterRecognizedLines judges. Line granularity on
+  // purpose: Tesseract's hallucinations (stylised art read as Latin garbage)
+  // arrive as whole low-scoring lines, whereas dropping individual words would
+  // silently rewrite sentences.
+  function flattenBlocks(blocks) {
+    const paragraphs = [];
+    for (const block of blocks || []) {
+      for (const paragraph of (block && block.paragraphs) || []) {
+        const lines = [];
+        for (const line of (paragraph && paragraph.lines) || []) {
+          if (!line) continue;
+          lines.push({
+            text: String(line.text || '').replace(/\n+$/, ''),
+            confidence: typeof line.confidence === 'number' ? line.confidence : null
+          });
+        }
+        if (lines.length) paragraphs.push(lines);
+      }
+    }
+    return paragraphs;
+  }
+
   async function recognize({ dataUrl, languages }, onProgress) {
     const worker = await getTesseractWorker(languages, onProgress);
-    const { data } = await worker.recognize(dataUrl);
+    // `blocks` carries the per-line confidences the filter below needs; `text`
+    // is kept as the fallback when a build answers without them — an
+    // unfiltered result still beats an empty one.
+    const { data } = await worker.recognize(dataUrl, {}, { text: true, blocks: true });
+
+    let raw = data && typeof data.text === 'string' ? data.text : '';
+    const paragraphs = data && Array.isArray(data.blocks) ? flattenBlocks(data.blocks) : [];
+    if (paragraphs.length) {
+      // The filter works on the flat list (its all-dropped fallback has to see
+      // the whole result); membership rebuilds the paragraph gaps, which the
+      // popup renders and the reader needs.
+      const kept = new Set(globalThis.OCRCore.filterRecognizedLines(paragraphs.flat()));
+      raw = paragraphs
+        .map((lines) => lines.filter((line) => kept.has(line)).map((line) => line.text).join('\n'))
+        .filter((text) => text.trim())
+        .join('\n\n');
+    }
+
     // Just the text: the same {text, language} contract the vision engine
     // answers with, minus the language, which the service worker derives.
-    return { text: globalThis.OCRCore.normalizeRecognizedText(data.text) };
+    return { text: globalThis.OCRCore.normalizeRecognizedText(raw) };
   }
 
   const HANDLERS = {

--- a/shared/ocr.js
+++ b/shared/ocr.js
@@ -178,6 +178,45 @@
       .trim();
   }
 
+  // --- Low-confidence line filtering -----------------------------------------
+
+  // Tesseract reads everything shaped like glyphs, including stylised display
+  // type and decorative art it has no model for — and those come out as Latin
+  // garbage lines ("SEE Fis 64, BEAR K. MASS 7 Ol eR") sitting next to
+  // perfectly good small text. It does, however, know when it was guessing:
+  // the hallucinated lines score far below the real ones, so its own
+  // confidence is the signal that separates them.
+  //
+  // 55 rather than higher because the two failure modes are not symmetric: a
+  // dropped real line is text the user can see in the image and we silently
+  // withheld, while a kept garbage line is only noise around a correct result.
+  // Clean print scores in the 80–95 band, small or slightly blurry but
+  // genuinely readable text falls into the 60s–70s, and the hallucinations
+  // from stylised glyphs sit in the 10s–40s — 55 lands in that gap, on the
+  // keep-more side of it.
+  const OCR_LINE_CONFIDENCE_THRESHOLD = 55;
+
+  /**
+   * Drop the lines Tesseract itself did not believe. `lines` is
+   * [{text, confidence}] in reading order, confidence 0–100 straight from the
+   * engine. The return is the surviving subset — order intact, the same
+   * objects — so a caller can rebuild paragraph structure by membership.
+   *
+   * If every line fails the bar, the input comes back untouched: an image
+   * that is *all* stylised type is exactly where the confidence stops meaning
+   * anything, and a low-confidence result the user can judge for themselves
+   * still beats an empty popup. A line with no numeric confidence is kept for
+   * the same reason — "unknown" is not "bad".
+   */
+  function filterRecognizedLines(lines) {
+    const all = Array.isArray(lines) ? lines : [];
+    const kept = all.filter((line) => {
+      if (!line || typeof line.confidence !== 'number' || !isFinite(line.confidence)) return true;
+      return line.confidence >= OCR_LINE_CONFIDENCE_THRESHOLD;
+    });
+    return kept.length > 0 ? kept : all;
+  }
+
   // --- Translation step ------------------------------------------------------
 
   /**
@@ -342,6 +381,8 @@ Rules:
     canSendImageDirectly,
     resolveOcrLanguages,
     detectScriptLanguage,
+    OCR_LINE_CONFIDENCE_THRESHOLD,
+    filterRecognizedLines,
     normalizeRecognizedText,
     detectedLanguageLabelKey,
     shouldTranslate,

--- a/test/unit/ocr-core.test.mjs
+++ b/test/unit/ocr-core.test.mjs
@@ -171,6 +171,66 @@ test('normalizing nothing yields an empty string, never throws', () => {
   assert.equal(OCR.normalizeRecognizedText(undefined), '');
 });
 
+// --- filterRecognizedLines ---------------------------------------------------
+
+test('low-confidence garbage lines are dropped, real lines survive in order', () => {
+  // The real bug: large stylised Chinese glyphs Tesseract has no model for,
+  // recognised as low-scoring Latin garbage next to correctly-read small text.
+  const lines = [
+    { text: '< rs', confidence: 21 },
+    { text: 'SEE Fis 64, BEAR K. MASS 7 Ol eR', confidence: 34 },
+    { text: '柳宗元', confidence: 91 },
+    { text: '裁剪编辑', confidence: 88 }
+  ];
+  assert.deepEqual(
+    OCR.filterRecognizedLines(lines).map((l) => l.text),
+    ['柳宗元', '裁剪编辑']
+  );
+});
+
+test('when every line is low confidence, the input comes back unfiltered', () => {
+  // A photo that is all stylised type is exactly where confidence stops
+  // meaning anything, and a shaky result still beats an empty popup.
+  const lines = [
+    { text: 'blurry one', confidence: 30 },
+    { text: 'blurry two', confidence: 41 }
+  ];
+  assert.deepEqual(OCR.filterRecognizedLines(lines), lines);
+});
+
+test('surviving lines keep their order and identity, so structure can be rebuilt', () => {
+  // The offscreen document rebuilds paragraph gaps by Set membership, which
+  // only works if the filter returns the same objects it was given.
+  const first = { text: 'Header', confidence: 90 };
+  const junk = { text: 'ol eR', confidence: 12 };
+  const last = { text: 'Body line', confidence: 84 };
+  const kept = OCR.filterRecognizedLines([first, junk, last]);
+  assert.equal(kept.length, 2);
+  assert.equal(kept[0], first);
+  assert.equal(kept[1], last);
+});
+
+test('a line with no numeric confidence is kept — unknown is not bad', () => {
+  const lines = [
+    { text: 'no score' },
+    { text: 'garbage', confidence: 10 },
+    { text: 'good', confidence: 95 }
+  ];
+  assert.deepEqual(OCR.filterRecognizedLines(lines).map((l) => l.text), ['no score', 'good']);
+});
+
+test('the threshold is inclusive at the bar and drops one point under it', () => {
+  const at = { text: 'at', confidence: OCR.OCR_LINE_CONFIDENCE_THRESHOLD };
+  const below = { text: 'below', confidence: OCR.OCR_LINE_CONFIDENCE_THRESHOLD - 1 };
+  assert.deepEqual(OCR.filterRecognizedLines([at, below]), [at]);
+});
+
+test('filtering nothing yields an empty array, never throws', () => {
+  assert.deepEqual(OCR.filterRecognizedLines([]), []);
+  assert.deepEqual(OCR.filterRecognizedLines(null), []);
+  assert.deepEqual(OCR.filterRecognizedLines(undefined), []);
+});
+
 // --- shouldTranslate ---------------------------------------------------------
 
 test('the translate step runs when it is on and the languages differ', () => {
@@ -334,6 +394,15 @@ test('the local engine runs in the offscreen document, not the worker', () => {
   for (const opt of ['corePath', 'workerPath', 'langPath', 'workerBlobURL', 'gzip']) {
     assert.ok(offscreen.includes(opt), `the engine must be pinned to the vendored ${opt}`);
   }
+});
+
+test('the offscreen document filters what it recognised before answering', () => {
+  // Without the structured output there are no per-line confidences, and
+  // without the filter the stylised-glyph garbage rides along with the real
+  // text and poisons language detection downstream.
+  const offscreen = repoFile('offscreen/offscreen.js');
+  assert.ok(/blocks:\s*true/.test(offscreen), 'recognize must request the structured blocks output');
+  assert.ok(offscreen.includes('filterRecognizedLines'), 'the confidence filter must run on the result');
 });
 
 test('the content script chain loads the OCR core and UI before the message router', () => {


### PR DESCRIPTION
## Background
- This PR packages the current branch changes for review.
- It groups the current branch updates into one reviewable change.

## Solution
- fix(ocr): drop the lines Tesseract itself did not believe

## Affected Files
- `offscreen/offscreen.js`
- `shared/ocr.js`
- `test/unit/ocr-core.test.mjs`