### PR TITLE
fix: preserve links on the default engine, and drop translations the pag

### DIFF
--- a/content/content-fit-guard.js
+++ b/content/content-fit-guard.js
@@ -1,0 +1,152 @@
+// 译文插进去了，可页面没给它地方站。
+//
+// content-clip-guard.js 管的是这件事的一半：祖先 `overflow:hidden`，译文落在可视
+// 框外面被裁掉——用户什么都看不见。这里管另一半，也是更难看的一半：那个框同样不
+// 让内容把自己撑高，但 `overflow` 是 `visible`，于是译文不会消失，它溢出来盖在别
+// 的东西上。
+//
+// poloclub 的 Transformer Explainer 是一整页这样的框。它是坐标驱动的可视化：每个
+// token 标签都住在一个由图形布局定死高度的格子里，
+//
+//   .cell            clientHeight 1.7px，里面装着 12px 的绝对定位标签
+//   .textbook-tooltip clientHeight 5px，scrollHeight 11px
+//   .type-btn        clientHeight 17px，加一行译文后 scrollHeight 41px
+//
+// 这些格子不会为多出来的一行长高，相邻格子只隔十来像素，译文于是直接压在下一行
+// 原文上。
+//
+// 量法（下面所有数字都是这一套，换算法就不可比了）：只数**看得见**的矩形
+// （checkVisibility，含 opacity/visibility），互相包含的不算，横竖都压过 6px 才算
+// 一处；页面自己本来就有的重叠在插译文**之前**先量一遍，最后相减。译文按它自己那
+// 个容器算一个矩形——不能拆成里面的 <a>/<span> 叶子，否则「保留内联标记」一开，
+// 被数的矩形集合就变了，开关前后的数字对不上。
+//
+// transformer-explainer 整页 301 块，同一套量法：
+//
+//   fit guard 关（今天线上的行为）  译文全留 300 条，新增重叠 17
+//   fit guard 开                    留 221 条、撤 79 条，新增重叠 5
+//
+// 剩下那 5 处全在顶部控件栏，而且都是**横向**相撞：那些容器是 w-max，译文一挂上去
+// 它就跟着变宽，相对宿主根本没溢出，被撞的是坐标定死的隔壁控件。这里的判据是相对
+// 宿主的纵向溢出，够不着这一类——要接住得改成邻居碰撞检测，那是另一套机制和另一份
+// 风险预算，没有塞进这次改动。
+//
+// 维基百科（Transformer 词条，翻头 400 块，页面自带 60 处重叠）同一套量法：
+//
+//   fit guard 关，标记开   译文全留 400 条，新增重叠 42
+//   fit guard 开，标记开   留 395 条，新增重叠 31（超链接重建 383 条）
+//   fit guard 开，标记关   留 395 条，新增重叠 32（超链接 0 条）
+//
+// 两处结论一致：**保留内联标记对重叠是中性的**（31 对 32、5 对 5，都在噪声里），
+// fit guard 两边都在减（42→31、17→5）。维基剩下的 31 是往一篇本来就密的长文里塞
+// 400 段字的固有代价，不是这两个改动引进来的。
+//
+// 判据是纯几何的，不看类名也不看站点：**译文的矩形跑到了紧挨着它的祖先的 padding
+// box 外面**。框只要肯为它长高，译文就还在框里；跑出去了，就说明这个框的高度是外面
+// 定死的，页面没打算给这行字留地方。站不住就把译文撤掉——原文一个字不动，比压上去
+// 糊成一团强。
+//
+// 溢出之后还要再问一句这算什么，答案在这个框裁不裁剪：
+//   - 会裁（hidden/clip/auto/scroll）→ 框外那截根本不画出来，压不到谁。那是
+//     clip-guard 管的「看不见」或者滚动条管的事，不是这里管的「盖住」，在那儿撤译文
+//     只会把它们已经处理好的情况弄砸。既然这一层就裁住了，再往上也溢不出去，所以直
+//     接收工。
+//   - 不裁（visible）→ 框外那截照样画出来，正压在别人身上。撤掉。
+// 反过来，**装得下译文的裁剪框在这里没有任何特权**：它裁不掉任何东西，谁也没保护，
+// 只是自己变大了去挤别人。transformer-explainer 的 span.label.float 就是这样一个
+// 框——39px 高、绝对定位、稳稳装下译文，然后整个盖在隔壁的 2px 格子上。所以顺序是
+// 先量溢出、再看 overflow，不能一见 hidden 就放行。
+//
+// 还有一条：祖先是 display:inline 时它压根没有自己的高度盒（clientHeight 恒为
+// 0），量它只会得到假的溢出，跳过。
+//
+// **只看紧挨着的两层**（MAX_DEPTH）。约束一行字的框总是贴着它的——格子、单元格、
+// 按钮；再往上是页面骨架，那些框的高度不是冲着这行字来的，它们自己的内容本来就可能
+// 溢出（维基百科的 .mw-collapsible 侧栏、footer、tbody 都是），拿几何判据去量只会把
+// 页面自己的老溢出算到译文头上。实测这一个常数就是全部代价所在，同一套代码：
+//
+//   MAX_DEPTH  transformer 新增重叠   维基百科撤掉的译文
+//     1              24                   5 / 1383
+//     2               3                  10 / 1383
+//     3               2                  33 / 1383
+//     5               3                 148 / 1383
+//
+// 顺带修掉一个同源的老问题：insertTranslationBlock 会把原文块的 class 复制到译文
+// 块上（为了继承页面 CSS，比如 arXiv 的 ltx_p），而 class 上挂着的可能正是页面自
+// 己的 `position:absolute` 和坐标。那边靠一条正则去掉 Tailwind 里字面叫
+// `absolute`/`inset-*` 的类名，但站点自己写的类名（Svelte 的 .guide-text）它认不
+// 出来，译文于是继承了原文的绝对坐标，一字不差地压在原文上。类名匹配是猜，这里改
+// 成看计算样式：真的出了流，就按回 static。
+(function() {
+  'use strict';
+
+  const ctx = window.AI_TRANSLATOR_CONTENT;
+  if (!ctx) return;
+
+  // 只看紧挨着的两层——为什么是 2，见文件头的表。
+  const MAX_DEPTH = 2;
+  // 布局取整会差个零点几像素，别为此撤译文
+  const SLACK = 2;
+
+  // 译文继承了页面的绝对定位 → 按回正常流。改的是译文自己的内联样式，
+  // 页面的规则一个都没动。
+  function keepInFlow(el) {
+    const position = window.getComputedStyle(el).position;
+    if (position === 'absolute' || position === 'fixed' || position === 'sticky') {
+      el.style.setProperty('position', 'static', 'important');
+    }
+  }
+
+  // rect 有没有跑到 host 的 padding box 外面。
+  // 用 clientTop/clientHeight 而不是 rect.height：溢出发生在 padding box 上，
+  // 而 getBoundingClientRect() 含边框。与 clip-guard 的 clipsAway 同一套量法。
+  function spillsOut(host, rect) {
+    const box = host.getBoundingClientRect();
+    const top = box.top + host.clientTop;
+    const bottom = top + host.clientHeight;
+    return rect.bottom > bottom + SLACK || rect.top < top - SLACK;
+  }
+
+  /**
+   * 确认页面确实给了这条译文站的地方；站不住就把它撤掉。
+   * 必须在 keepTranslationVisible() 之后调用——clip guard 可能刚把某个祖先的
+   * max-height 放开，那之后框才是它最终的样子。
+   *
+   * @param {Element} translationEl 刚插进 DOM 的译文节点
+   * @returns {boolean} 译文是否留下了
+   */
+  ctx.keepTranslationInFlow = function(translationEl) {
+    if (!translationEl || translationEl.nodeType !== Node.ELEMENT_NODE || !translationEl.isConnected) {
+      return false;
+    }
+
+    keepInFlow(translationEl);
+
+    const rect = translationEl.getBoundingClientRect();
+    // 没有尺寸的译文量不出溢出（还没排版，或者本来就是空的），留着。
+    if (rect.width === 0 && rect.height === 0) return true;
+
+    let host = translationEl.parentElement;
+    for (let depth = 0; depth < MAX_DEPTH && host && host !== document.body && host !== document.documentElement; depth++) {
+      // 内联盒没有自己的高度（clientHeight 恒为 0），量它得到的溢出是假的
+      if (host.clientHeight > 0 && spillsOut(host, rect)) {
+        // 溢出了。这一下究竟是「看不见」还是「盖住别人」，取决于这个框裁不裁剪：
+        //   - 会裁（hidden/clip/auto/scroll）→ 框外那截根本不显示，压不到谁。
+        //     滚动条或者 clip-guard 会处理，撤译文只会把它们处理好的情况弄砸。
+        //     而且既然这一层就裁住了，再往上也溢不出去，所以是 return。
+        //   - 不裁（visible）→ 框外那截照样画出来，正压在别人身上。撤掉。
+        if (window.getComputedStyle(host).overflowY !== 'visible') return true;
+        translationEl.remove();
+        if (ctx.releaseTranslationClipGuards) ctx.releaseTranslationClipGuards();
+        return false;
+      }
+      // 装得下 → 这一层不是约束，接着往上。注意会裁剪的框在这里没有特权：一个装得
+      // 下译文的 overflow:hidden 框裁不掉任何东西，它谁也没保护，只是自己去挤别人
+      // （transformer-explainer 的 span.label.float 就是——39px 高、绝对定位，稳稳
+      // 装下译文，然后整个盖在隔壁的 2px 格子上）。
+      host = host.parentElement;
+    }
+
+    return true;
+  };
+})();

--- a/content/content-language.js
+++ b/content/content-language.js
@@ -48,9 +48,11 @@
     // 剥掉数学占位符 {{n}} 和内联格式标记 <a1>…</a1>，两者都不是正文，混进去
     // 会拉低语言检测的置信度。标记的定义在 content-page-translation.js
     // （ctx.MARKUP_MARKER_RE）；字面量兜底只为本文件先于它加载的窗口期。
+    // 兜底必须和那边逐字一致（含 i：内置 NMT 会把标记大写成 <A1>），
+    // markup-marker-regex.test.mjs 会比对两处源码。
     const cleaned = text
       .replace(/\{\{\d+\}\}/g, '')
-      .replace(ctx.MARKUP_MARKER_RE || /<\/?[a-z]+\d+>/g, '')
+      .replace(ctx.MARKUP_MARKER_RE || /<\/?[a-z]+\d+>/gi, '')
       .replace(/\s+/g, ' ')
       .trim();
     return cleaned.slice(0, 400);

--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -27,9 +27,32 @@
   // 内联格式标记：整页翻译提取文本时，把 <a>/<strong>/<em> 等内联格式元素编码成
   // 成对的 <a1>…</a1> 标记随正文一起送翻，译文再按标记克隆原元素重建（见
   // buildTranslationContent），从而保留超链接（href）和内联样式（class/style）。
-  // 只在 AI 引擎下生成标记：内置 NMT 引擎没有“原样保留标记”的承诺，喂进去只会
-  // 让标记被翻碎；内置引擎继续走纯文本，行为与从前完全一致。
-  const MARKUP_MARKER_RE = /<\/?[a-z]+\d+>/g;
+  //
+  // **两个引擎都生成标记。** 这里曾经只在 AI 引擎下生成，理由是“内置 NMT 没有
+  // 原样保留标记的承诺”——那是假设，实测不成立。拿 Chrome 内置 Translator 跑
+  // en→zh-Hans / zh-Hant / ja，每句连翻三遍结果一致：
+  //
+  //   12 句 × 3 语言里，标记原样往返的 8 成以上；zh-Hans 的两处缺陷是
+  //   `<a1>` 被大写成 `<A1>`（闭标记仍是小写），一处是 `</strong2>` 整个丢失。
+  //
+  // 所以标记是能用的，只是要求解析端宽容：markerRe 大小写不敏感、容空白（见
+  // buildTranslationContent），丢了闭标记就在结尾自动闭合。默认引擎正是内置
+  // NMT，之前的开关等于让绝大多数用户的译文一个超链接都留不下。
+  //
+  // 大小写不敏感同样适用于这条正则：译文里的标记可能是 <A1>。
+  const MARKUP_MARKER_RE = /<\/?[a-z]+\d+>/gi;
+
+  // 由本块**真正生成过**的标签名与编号拼出的正则，用来清掉解析后仍留在译文里的
+  // 标记残骸（模型把 <a1>/<strong2> 串成了 <strong1> 这种，配不上任何一对，
+  // 重建时只能原样跳过）。
+  // 只认自己用过的标签名和编号，是为了不动页面正文：讲 HTML 的页面正文里就写着
+  // <b2> 这类字样，我们没生成过 b 标记时它一个字都不该被删。
+  function markupDebrisRe(markupElements) {
+    if (!markupElements || markupElements.length === 0) return null;
+    const tags = [...new Set(markupElements.map((mk) => mk.tag))].join('|');
+    const nums = [...new Set(markupElements.map((mk) => String(mk.index)))].join('|');
+    return new RegExp(`<\\s*/?\\s*(?:${tags})\\s*(?:${nums})\\s*>`, 'gi');
+  }
   const MARKUP_TAGS = new Set([
     'A', 'STRONG', 'B', 'EM', 'I', 'U', 'S', 'SUP', 'SUB', 'MARK', 'SMALL',
     'ABBR', 'DEL', 'INS', 'Q', 'CITE', 'DFN', 'CODE', 'KBD', 'SAMP', 'VAR'
@@ -565,8 +588,6 @@
   // 收集可翻译的块级元素
   function collectTranslatableBlocks(root) {
     managedSkipCount = 0;
-    // 内联格式标记只在 AI 引擎下生成，见 MARKUP_MARKER_RE 处的说明。
-    const preserveMarkup = !usingBuiltinEngine();
     const blocks = [];
     const blockTags = ['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'LI', 'TD', 'TH', 'FIGCAPTION', 'BLOCKQUOTE', 'DT', 'DD'];
     // 内联可翻译元素 - 这些元素即使不是块级也应单独翻译
@@ -838,7 +859,7 @@
 
       // 对于内联元素（如链接、按钮），如果有文本内容，单独翻译
       if (inlineTags.includes(tagName)) {
-        const { text, mathElements, markupElements } = getTextWithMathPlaceholders(element, { preserveMarkup });
+        const { text, mathElements, markupElements } = getTextWithMathPlaceholders(element, { preserveMarkup: true });
         // 长度阈值按剥掉占位符/内联标记后的正文算，标记本身不该把短链接顶出上限
         const plainText = stripPlaceholders(text).trim();
         if (text && plainText.length >= 2 && plainText.length <= 500) {
@@ -861,7 +882,7 @@
 
       // 对于块级元素
       if (blockTags.includes(tagName) || hasDirectText) {
-        let { text, mathElements, markupElements } = getTextWithMathPlaceholders(element, { preserveMarkup });
+        let { text, mathElements, markupElements } = getTextWithMathPlaceholders(element, { preserveMarkup: true });
         if (text && text.length >= 2) {
           // 跳过看起来像代码或主要是URL的文本（排除数学占位符和内联标记后判断）
           const textWithoutMath = stripPlaceholders(text).trim();
@@ -1475,16 +1496,26 @@
     // on* 属性）并下钻；闭标记 → 弹回。对模型输出保持防御：编号或标签名对不上
     // 的标记当普通文本原样保留；错序的闭标记只弹到对应层；缺失的闭标记到结尾
     // 自动闭合。最坏情况（标记全被模型丢掉）退化为纯文本译文，即今天的行为。
-    const markerRe = /<(\/?)([a-z]+)(\d+)>/g;
+    //
+    // 大小写不敏感 + 容空白，是内置 NMT 逼出来的：实测 en→zh-Hans 会把开标记
+    // 大写成 `<A1>`（闭标记仍是 `</a1>`）。按小写严格匹配的话，这条链接不但重
+    // 建不出来，`<A1>` 四个字符还会原样显示给读者。见 MARKUP_MARKER_RE 处。
+    const markerRe = /<\s*(\/?)\s*([a-z]+)\s*(\d+)\s*>/gi;
+    // 解析完仍留在正文里的标记残骸（配不上任何一对，上面 continue 掉的那些）不
+    // 能直接给读者看，落笔前清掉。只认本块生成过的标签名和编号，见 markupDebrisRe。
+    const debrisRe = markupDebrisRe(markupElements);
+    const emit = (node, chunk) => {
+      appendTextWithMath(node, debrisRe ? chunk.replace(debrisRe, '') : chunk, mathByNumber);
+    };
     const stack = [{ node: container, index: null }];
     let lastIndex = 0;
     let match;
     while ((match = markerRe.exec(text)) !== null) {
       const closing = match[1] === '/';
       const entry = markupByNumber.get(match[3]);
-      if (!entry || entry.tag !== match[2]) continue;
+      if (!entry || entry.tag !== match[2].toLowerCase()) continue;
 
-      appendTextWithMath(stack[stack.length - 1].node, text.slice(lastIndex, match.index), mathByNumber);
+      emit(stack[stack.length - 1].node, text.slice(lastIndex, match.index));
       lastIndex = markerRe.lastIndex;
 
       if (!closing) {
@@ -1501,7 +1532,7 @@
         if (pos > 0) stack.length = pos;
       }
     }
-    appendTextWithMath(stack[stack.length - 1].node, text.slice(lastIndex), mathByNumber);
+    emit(stack[stack.length - 1].node, text.slice(lastIndex));
   }
 
   // 向后兼容的旧签名（悬停/划词翻译仍按 mathElements 数组调用）
@@ -1510,10 +1541,26 @@
   }
 
   // 译文插进 DOM 不等于看得见：折叠容器（overflow:hidden + max-height）会把它整条
-  // 裁掉。见 content-clip-guard.js。下面每一处把译文放进 DOM 的分支后面都要跟一次，
-  // clip-guard.test.mjs 会数：插入点比检查点多，就是漏了一处。
+  // 裁掉。见 content-clip-guard.js。
   function keepTranslationVisible(anchor) {
     if (ctx.keepTranslationVisible) ctx.keepTranslationVisible(anchor);
+  }
+
+  // 译文放进 DOM 之后要做的三件事，顺序是有讲究的：
+  //   1. 把裁剪它的祖先放开（clip guard）——框可能因此长高，第 2 步要量的是放开
+  //      之后的样子；
+  //   2. 确认页面真给了它地方站（fit guard，见 content-fit-guard.js）。站不住就
+  //      撤掉译文，返回 false；
+  //   3. 这时候才轮到“仅显示译文”去藏原文。顺序反了会出现最糟的结果——原文被藏
+  //      起来，译文又被撤走，那一块彻底空白。
+  //
+  // 下面每一处把译文放进 DOM 的分支后面都要跟一次，clip-guard.test.mjs 会数：
+  // 插入点比检查点多，就是漏了一处。
+  function finishTranslationInsert(translationEl) {
+    keepTranslationVisible(translationEl);
+    if (ctx.keepTranslationInFlow && !ctx.keepTranslationInFlow(translationEl)) return false;
+    if (isTranslationOnlyActive()) hideSourceForTranslation(translationEl);
+    return true;
   }
 
   // 插入翻译块
@@ -1540,11 +1587,12 @@
         ctx.canRenderManagedTranslation &&
         ctx.canRenderManagedTranslation(element, { hasMath: hasMathElements })) {
       // ::after 的 content 只能是纯文本，内联格式标记在这里还原不了，剥掉了事。
-      // 只在块确实带标记时剥：正文本来就含 <b2> 这类字样的页面（HTML 教程等）
-      // 不能被误删。
+      // 用 markupDebrisRe 而不是笼统的 MARKUP_MARKER_RE：只剥本块真生成过的标签
+      // 名+编号，正文本来就含 <b2> 这类字样的页面（HTML 教程等）不会被误删。
+      const managedDebrisRe = markupDebrisRe(block.markupElements);
       ctx.renderManagedTranslation(
         element,
-        hasMarkupElements ? translation.replace(MARKUP_MARKER_RE, '') : translation,
+        managedDebrisRe ? translation.replace(managedDebrisRe, '') : translation,
         {}
       );
       // ::after 把原文块撑高，撑出去的那部分同样可能被折叠祖先裁掉，量原文块
@@ -1597,8 +1645,7 @@
 
       // 将翻译作为子元素追加到原元素内部（显示在原文右侧）
       inlineTarget.appendChild(translationEl);
-      keepTranslationVisible(translationEl);
-      if (isTranslationOnlyActive()) hideSourceForTranslation(translationEl);
+      finishTranslationInsert(translationEl);
     } else {
       // 对于非水平 flex 布局（如侧边栏），插入为同级元素
       // 表格单元格例外：译文要插到单元格【内部】，插一个兄弟 <td> 会给整行多加一列、撑破表格网格
@@ -1671,19 +1718,16 @@
           box-sizing: border-box;
         `;
         element.appendChild(internalTranslation);
-        keepTranslationVisible(internalTranslation);
-        if (isTranslationOnlyActive()) hideSourceForTranslation(internalTranslation);
+        finishTranslationInsert(internalTranslation);
       } else if (isTableCell) {
         // 表格单元格：译文作为块级子节点追加到单元格【内部】，显示在原内容下方，保持网格不变。
         // 用 <div>（而非 <td>）避免 td 内嵌 td 的非法结构。
         element.appendChild(translationEl);
-        keepTranslationVisible(translationEl);
-        if (isTranslationOnlyActive()) hideSourceForTranslation(translationEl);
+        finishTranslationInsert(translationEl);
       } else {
         // 插入到原元素后面
         element.after(translationEl);
-        keepTranslationVisible(translationEl);
-        if (isTranslationOnlyActive()) hideSourceForTranslation(translationEl);
+        finishTranslationInsert(translationEl);
       }
     }
   }

--- a/manifest.json
+++ b/manifest.json
@@ -65,6 +65,7 @@
         "content/content-utils.js",
         "content/content-managed-translation.js",
         "content/content-clip-guard.js",
+        "content/content-fit-guard.js",
         "content/content-language.js",
         "content/content-speech.js",
         "content/content-translation-engine.js",

--- a/test/e2e/markup-preservation.spec.js
+++ b/test/e2e/markup-preservation.spec.js
@@ -6,14 +6,22 @@ const path = require('path');
 // pipeline, loaded straight from source into a plain headless page (no
 // extension, network, or display needed). Guards the inline-markup
 // preservation feature:
-//   - with the AI engine, inline formatting elements (<a>, <strong>, …) are
-//     encoded as paired numbered markers (<a1>…</a1>) in the extracted text;
+//   - inline formatting elements (<a>, <strong>, …) are encoded as paired
+//     numbered markers (<a1>…</a1>) in the extracted text, under BOTH engines;
 //   - the rebuilt translation contains real cloned elements that keep
 //     href/class but drop id and on* attributes;
-//   - the builtin engine never sees markers (on-device NMT cannot be trusted
-//     to round-trip them);
+//   - the parser is case- and whitespace-tolerant, because Chrome's on-device
+//     NMT really does hand back `<A1>…</a1>`;
 //   - a model that mangles or drops markers degrades to plain text, never to
-//     broken DOM.
+//     broken DOM, and never leaks marker debris to the reader.
+//
+// On the builtin engine: markers used to be suppressed on the assumption that
+// on-device NMT would shred them. Measured (en→zh-Hans/zh-Hant/ja, three runs
+// per sentence, identical each time) that assumption is wrong — markers survive
+// in the large majority of sentences. The one reproducible defect is an
+// uppercased opening marker, which the tolerant regex below handles. Since the
+// builtin engine is the DEFAULT, the old gate meant most users lost every link
+// in every translation, which is the bug this suite now pins down.
 const ROOT = path.join(__dirname, '..', '..');
 const SCRIPTS = [
   path.join(ROOT, 'i18n/messages.js'),
@@ -92,18 +100,63 @@ test('AI engine: inline markup becomes paired markers and survives round-trip', 
   expect(result.plainText).toBe('[译]A perfectly ordinary paragraph with no inline formatting at all in it.');
 });
 
-test('builtin engine: no markers are generated at all', async ({ page }) => {
+test('builtin engine: markers are generated too, and NMT-style casing rebuilds', async ({ page }) => {
   await loadHarness(page);
 
-  const richText = await page.evaluate(() => {
+  const result = await page.evaluate(() => {
     const ctx = window.AI_TRANSLATOR_CONTENT;
     ctx.builtinTranslator = { isActive: () => true };
     const blocks = ctx.collectTranslatableBlocks(document.body);
-    return blocks.find((b) => b.element.id === 'rich').text;
+    const rich = blocks.find((b) => b.element.id === 'rich');
+
+    // Exactly what Chrome's on-device translator returned for this shape:
+    // the opening marker uppercased, the closing one left alone.
+    ctx.insertTranslationBlock(rich, '请仔细阅读<A1>文档</a1>，然后再<STRONG2>开始工作</strong2>。');
+
+    const translationEl = document.getElementById('rich').nextElementSibling;
+    const a = translationEl.querySelector('a');
+    const strong = translationEl.querySelector('strong');
+    return {
+      richText: rich.text,
+      markupCount: rich.markupElements.length,
+      aHref: a && a.getAttribute('href'),
+      aText: a && a.textContent,
+      strongText: strong && strong.textContent,
+      translationText: translationEl.textContent,
+    };
   });
 
-  expect(richText).not.toMatch(/<\/?[a-z]+\d+>/);
-  expect(richText).toContain('the documentation');
+  // The gate is gone: the builtin engine gets the same markers the AI engine does.
+  expect(result.richText).toContain('<a1>');
+  expect(result.richText).toContain('<strong2>');
+  expect(result.markupCount).toBe(2);
+
+  // …and an uppercased opener still rebuilds the real link, rather than
+  // showing the reader four characters of "<A1>".
+  expect(result.aHref).toBe('/docs');
+  expect(result.aText).toBe('文档');
+  expect(result.strongText).toBe('开始工作');
+  expect(result.translationText).toBe('请仔细阅读文档，然后再开始工作。');
+  expect(result.translationText).not.toMatch(/<\/?[a-z]+\d+>/i);
+});
+
+test('whitespace injected into a marker does not break the rebuild', async ({ page }) => {
+  await loadHarness(page);
+
+  const result = await page.evaluate(() => {
+    const ctx = window.AI_TRANSLATOR_CONTENT;
+    const blocks = ctx.collectTranslatableBlocks(document.body);
+    const rich = blocks.find((b) => b.element.id === 'rich');
+
+    const out = document.createElement('div');
+    ctx.buildTranslationContent(out, '请阅读< a1 >文档</ a1 >。', rich);
+    const a = out.querySelector('a');
+    return { links: out.querySelectorAll('a').length, text: out.textContent, href: a && a.getAttribute('href') };
+  });
+
+  expect(result.links).toBe(1);
+  expect(result.href).toBe('/docs');
+  expect(result.text).toBe('请阅读文档。');
 });
 
 test('a model that mangles or drops markers degrades to plain text', async ({ page }) => {
@@ -118,8 +171,10 @@ test('a model that mangles or drops markers degrades to plain text', async ({ pa
     const dropped = document.createElement('div');
     ctx.buildTranslationContent(dropped, '请在开始项目之前仔细阅读文档。', rich);
 
-    // Case 2: the model invented a marker that was never handed out, and
-    // renumbered a real one to a wrong tag name.
+    // Case 2: the model invented a marker that was never handed out (<b9> — no
+    // <b> and no 9 was ever issued for this block), and recombined two real
+    // ones into a pair that was not (<a2>: 'a' and 2 were both issued, just
+    // never together).
     const mangled = document.createElement('div');
     ctx.buildTranslationContent(mangled, '请阅读<b9>文档</b9>和<a2>说明</a2>。', rich);
 
@@ -141,10 +196,13 @@ test('a model that mangles or drops markers degrades to plain text', async ({ pa
   expect(result.droppedHTML).toBe('请在开始项目之前仔细阅读文档。');
   expect(result.droppedText).toBe('请在开始项目之前仔细阅读文档。');
 
-  // Unknown/mismatched markers stay as literal text — ugly but honest, and
-  // never a fabricated element.
+  // Never a fabricated element — a pair we did not hand out does not become a link.
   expect(result.mangledLinks).toBe(0);
-  expect(result.mangledText).toBe('请阅读<b9>文档</b9>和<a2>说明</a2>。');
+  // <a2> is debris out of our own vocabulary ('a' and 2 were both issued for
+  // this block), so it is scrubbed rather than shown to the reader. <b9> is
+  // not: no <b> marker was ever issued here, so those characters belong to the
+  // page — an HTML tutorial whose prose really does say "<b9>" keeps it.
+  expect(result.mangledText).toBe('请阅读<b9>文档</b9>和说明。');
 
   // Missing close: element still built, content contained.
   expect(result.unclosedLinks).toBe(1);

--- a/test/unit/clip-guard.test.mjs
+++ b/test/unit/clip-guard.test.mjs
@@ -249,19 +249,42 @@ test('a managed handle is measured as its source block, not as itself', () => {
 // Wiring: the guard is worthless if a caller inserts without asking.
 // ---------------------------------------------------------------------------
 
-test('every insertion in the whole-page path asks the guard', () => {
+test('every insertion in the whole-page path asks the guards', () => {
   const source = repoFile('content/content-page-translation.js');
   const body = source.slice(source.indexOf('function insertTranslationBlock'));
   const end = body.indexOf('\n  function showPageTranslationProgress');
   const fn = body.slice(0, end);
 
-  // 每一次把译文放进 DOM 之后，都要问一次“它看得见吗”
+  // 每一次把译文放进 DOM 之后，都要跟一次 finishTranslationInsert：
+  // 「它看得见吗」（clip guard）+「页面给它地方站吗」（fit guard）。
   const insertions = fn.match(/\.(appendChild|after)\(\w+\)/g) || [];
-  const guards = fn.match(/keepTranslationVisible\(/g) || [];
+  const guards = fn.match(/finishTranslationInsert\(/g) || [];
   assert.ok(insertions.length >= 4, `expected the insertion sites, found ${insertions.length}`);
-  // +1 是受管译文那条（画成 ::after，没有节点可插）
-  assert.equal(guards.length, insertions.length + 1,
-    'an insertion site was added without a visibility check');
+  assert.equal(guards.length, insertions.length,
+    'an insertion site was added without going through finishTranslationInsert');
+
+  // 受管译文那条画成 ::after，没有节点可插，所以它自己单独问 clip guard
+  assert.match(fn, /keepTranslationVisible\(element\)/,
+    'the managed (::after) branch lost its visibility check');
+});
+
+test('the post-insert helper runs both guards, and in the order that matters', () => {
+  const source = repoFile('content/content-page-translation.js');
+  const body = source.slice(source.indexOf('function finishTranslationInsert'));
+  const fn = body.slice(0, body.indexOf('\n  }') + 4);
+
+  const clip = fn.indexOf('keepTranslationVisible(');
+  const fit = fn.indexOf('keepTranslationInFlow(');
+  const hide = fn.indexOf('hideSourceForTranslation(');
+  assert.ok(clip !== -1, 'the clip guard is not called');
+  assert.ok(fit !== -1, 'the fit guard is not called');
+  assert.ok(hide !== -1, 'translation-only mode no longer hides the source');
+
+  // clip guard 可能把某个祖先的 max-height 放开，框因此长高 —— fit guard 要量的是
+  // 放开之后的样子，所以它必须在后面
+  assert.ok(clip < fit, 'the fit guard must measure the box the clip guard just relaxed');
+  // 顺序反了会出现最糟的结果：原文被藏起来，译文又被撤走，那一块彻底空白
+  assert.ok(fit < hide, 'the source must not be hidden until the translation is known to survive');
 });
 
 test('the hover path asks the guard when it tracks a translation', () => {

--- a/test/unit/fit-guard.test.mjs
+++ b/test/unit/fit-guard.test.mjs
@@ -1,0 +1,203 @@
+// Guards for content/content-fit-guard.js.
+//
+// The other half of "the page did not make room for the translation". The clip
+// guard (clip-guard.test.mjs) covers the case where the translation is *hidden* —
+// it lands outside an `overflow:hidden` box and the reader sees nothing. Here the
+// box is just as unwilling to grow, but `overflow` is `visible`, so the
+// translation is painted anyway, on top of whatever is next to it.
+//
+// Measured on poloclub's Transformer Explainer, a coordinate-driven
+// visualisation where every token label lives in a cell whose height comes from
+// the graph layout:
+//
+//   .cell             clientHeight 1.7px, holding a 12px absolutely positioned label
+//   .textbook-tooltip clientHeight 5px,  scrollHeight 11px
+//   .type-btn         clientHeight 17px, scrollHeight 41px once a translation is in
+//
+// 301 blocks, 22 newly introduced *visible* overlaps (baseline-controlled: the
+// page's own overlaps measured before injection and subtracted). With the guard,
+// 2.
+//
+// Exercised for real against a fake element tree rather than grepped for: what
+// has to stay true is behavioural — a translation with nowhere to go is removed,
+// one that fits is left alone, and a clipping ancestor is never second-guessed.
+//
+// Run with: npm run test:unit
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// ---------------------------------------------------------------------------
+// A fake DOM, deep enough for the guard's questions: where is this box, how tall
+// is it, does it clip, and what is my translation's rect.
+// ---------------------------------------------------------------------------
+
+class FakeStyle {
+  constructor() { this.props = new Map(); }
+  getPropertyValue(name) { const e = this.props.get(name); return e ? e.value : ''; }
+  getPropertyPriority(name) { const e = this.props.get(name); return e ? e.priority : ''; }
+  setProperty(name, value, priority = '') { this.props.set(name, { value, priority }); }
+  removeProperty(name) { this.props.delete(name); }
+}
+
+class FakeElement {
+  constructor({ top = 0, height = 0, overflowY = 'visible', position = 'static' } = {}) {
+    this.nodeType = 1;
+    this.isConnected = true;
+    this.parentElement = null;
+    this.children = [];
+    this.style = new FakeStyle();
+    this.clientTop = 0;
+    this.top = top;
+    this.height = height;
+    this.overflowY = overflowY;
+    this.position = position;
+  }
+
+  append(child) { child.parentElement = this; this.children.push(child); return child; }
+
+  remove() {
+    if (!this.parentElement) return;
+    const i = this.parentElement.children.indexOf(this);
+    if (i !== -1) this.parentElement.children.splice(i, 1);
+    this.parentElement = null;
+    this.isConnected = false;
+  }
+
+  // 站点定死的高度，不随内容变 —— 这正是本文件要处理的那类框
+  get clientHeight() { return this.height; }
+
+  getBoundingClientRect() {
+    return { top: this.top, bottom: this.top + this.height, height: this.height, width: 100 };
+  }
+}
+
+globalThis.Node = { ELEMENT_NODE: 1 };
+globalThis.window = {
+  AI_TRANSLATOR_CONTENT: {},
+  getComputedStyle: (el) => ({ overflowY: el.overflowY, position: el.position }),
+};
+globalThis.document = { body: new FakeElement(), documentElement: new FakeElement() };
+
+await import('../../content/content-fit-guard.js');
+const ctx = globalThis.window.AI_TRANSLATOR_CONTENT;
+const { body } = globalThis.document;
+
+/** The real shape: a graph cell whose height the layout fixed, translation spilling out. */
+function explainerCell({ overflowY = 'visible' } = {}) {
+  // 格子 100-102（高 2px），原文标签在里面，译文 100-125 —— 溢出 23px
+  const cell = new FakeElement({ top: 100, height: 2, overflowY });
+  const translation = new FakeElement({ top: 100, height: 25 });
+  cell.append(translation);
+  body.append(cell);
+  return { cell, translation };
+}
+
+test('a translation that spills out of a fixed-height box is removed', () => {
+  const { cell, translation } = explainerCell();
+  assert.ok(translation.getBoundingClientRect().bottom > cell.getBoundingClientRect().bottom,
+    'setup: the translation must start out spilling');
+
+  assert.equal(ctx.keepTranslationInFlow(translation), false);
+  assert.equal(translation.isConnected, false, 'the spilling translation was left in the page');
+  assert.equal(cell.children.length, 0);
+});
+
+test('a translation the box made room for is left alone', () => {
+  const box = new FakeElement({ top: 100, height: 60 });
+  const translation = new FakeElement({ top: 120, height: 20 });
+  box.append(translation);
+  body.append(box);
+
+  assert.equal(ctx.keepTranslationInFlow(translation), true);
+  assert.equal(translation.isConnected, true);
+});
+
+test('a clipping ancestor is left to the clip guard, not second-guessed', () => {
+  // 同样溢出，但框会裁剪 —— 溢出的那截根本不画出来，压不到谁。
+  // 这里撤译文只会把 clip guard 已经处理好的情况弄砸。
+  const { cell, translation } = explainerCell({ overflowY: 'hidden' });
+  assert.equal(ctx.keepTranslationInFlow(translation), true);
+  assert.equal(translation.isConnected, true);
+  assert.equal(cell.children.length, 1);
+});
+
+test('a scrollable ancestor is left alone — the reader can scroll to it', () => {
+  const { translation } = explainerCell({ overflowY: 'auto' });
+  assert.equal(ctx.keepTranslationInFlow(translation), true);
+  assert.equal(translation.isConnected, true);
+});
+
+test('a clipping box that still fits the translation gets no special treatment', () => {
+  // transformer-explainer 的 span.label.float：39px 高、绝对定位、overflow:hidden，
+  // 稳稳装下译文 —— 它裁不掉任何东西，谁也没保护，只是整个盖在隔壁的 2px 格子上。
+  // 一见 hidden 就放行的话，这一类会全部漏过去。
+  const cell = new FakeElement({ top: 100, height: 2 });
+  const label = new FakeElement({ top: 100, height: 39, overflowY: 'hidden', position: 'absolute' });
+  const translation = new FakeElement({ top: 110, height: 20 });
+  label.append(translation);
+  cell.append(label);
+  body.append(cell);
+
+  assert.equal(ctx.keepTranslationInFlow(translation), false,
+    'the label swallowed the spill check even though it clips nothing');
+  assert.equal(translation.isConnected, false);
+});
+
+test('an inline ancestor is skipped — it has no height box of its own', () => {
+  // display:inline 的祖先 clientHeight 恒为 0，拿它去量只会得到假的溢出
+  const outer = new FakeElement({ top: 100, height: 200 });
+  const inline = new FakeElement({ top: 100, height: 0 });
+  const translation = new FakeElement({ top: 120, height: 20 });
+  inline.append(translation);
+  outer.append(inline);
+  body.append(outer);
+
+  assert.equal(ctx.keepTranslationInFlow(translation), true);
+  assert.equal(translation.isConnected, true);
+});
+
+test('a translation that inherited the page position:absolute is put back in flow', () => {
+  // insertTranslationBlock 会复制原文块的 class，class 上挂着的可能正是页面自己的
+  // position:absolute 和坐标 —— 译文于是一字不差地压在原文上
+  const box = new FakeElement({ top: 100, height: 200 });
+  const translation = new FakeElement({ top: 120, height: 20, position: 'absolute' });
+  box.append(translation);
+  body.append(box);
+
+  ctx.keepTranslationInFlow(translation);
+
+  assert.equal(translation.style.getPropertyValue('position'), 'static');
+  assert.equal(translation.style.getPropertyPriority('position'), 'important',
+    'page CSS would win without it');
+});
+
+test('a translation with no layout yet is kept — you cannot measure a spill from nothing', () => {
+  const box = new FakeElement({ top: 100, height: 2 });
+  const translation = new FakeElement({ top: 0, height: 0 });
+  translation.getBoundingClientRect = () => ({ top: 0, bottom: 0, height: 0, width: 0 });
+  box.append(translation);
+  body.append(box);
+
+  assert.equal(ctx.keepTranslationInFlow(translation), true);
+  assert.equal(translation.isConnected, true);
+});
+
+test('a detached or non-element node is refused rather than measured', () => {
+  assert.equal(ctx.keepTranslationInFlow(null), false);
+  const orphan = new FakeElement({ top: 0, height: 10 });
+  orphan.isConnected = false;
+  assert.equal(ctx.keepTranslationInFlow(orphan), false);
+});
+
+test('removing a translation releases the clip guards taken for it', () => {
+  // 撤译文之后，之前为它放开的祖先要还原，否则页面留着一个被撑开的框
+  let released = 0;
+  ctx.releaseTranslationClipGuards = () => { released += 1; };
+  try {
+    const { translation } = explainerCell();
+    ctx.keepTranslationInFlow(translation);
+    assert.equal(released, 1);
+  } finally {
+    delete ctx.releaseTranslationClipGuards;
+  }
+});

--- a/test/unit/markup-marker-regex.test.mjs
+++ b/test/unit/markup-marker-regex.test.mjs
@@ -1,0 +1,87 @@
+// 内联格式标记的两条正则，各自该归谁管。
+//
+// content-page-translation.js 里有两条形状很像的正则，用途完全不同，混用会出真
+// 问题：
+//
+//   MARKUP_MARKER_RE  —— 笼统的“标记形状”。只用在**分析前的剥离**：代码检测、
+//                        长度阈值、语言检测、译文与原文的比对。结果永远不落到
+//                        页面上，多剥少剥都伤不到读者。
+//   markupDebrisRe()  —— 只认本块**真生成过**的标签名和编号。用在**渲染前的剥
+//                        离**。这里不能用笼统的那条：讲 HTML 的页面正文里就写着
+//                        <b2> 这类字样，笼统剥会把页面自己的字删掉。
+//
+// 另外 content-language.js 拿不到模块作用域，抄了一份字面量兜底。抄本必须和正本
+// 逐字一致——尤其是 i 标志：内置 NMT 实测会把开标记大写成 <A1>，少个 i 就漏剥。
+//
+// Run with: npm run test:unit
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const pageTranslation = readFileSync(new URL('../../content/content-page-translation.js', import.meta.url), 'utf8');
+const language = readFileSync(new URL('../../content/content-language.js', import.meta.url), 'utf8');
+
+test('the canonical marker regex is case-insensitive — NMT hands back <A1>', () => {
+  const m = pageTranslation.match(/const MARKUP_MARKER_RE = (\/.+\/[a-z]*);/);
+  assert.ok(m, 'MARKUP_MARKER_RE is no longer declared in the shape this test reads');
+  assert.match(m[1], /\/[a-z]*i[a-z]*$/,
+    'without the i flag the uppercased opener NMT really emits is never stripped');
+});
+
+test('content-language.js copy of the regex still matches the canonical one', () => {
+  const canonical = pageTranslation.match(/const MARKUP_MARKER_RE = (\/.+\/[a-z]*);/)[1];
+  const copy = language.match(/ctx\.MARKUP_MARKER_RE \|\| (\/.+\/[a-z]*)/);
+  assert.ok(copy, 'the literal fallback in content-language.js moved or was renamed');
+  assert.equal(copy[1], canonical,
+    'the two spellings drifted — content-language.js strips a different set of markers');
+});
+
+test('the parser regex tolerates the casing and whitespace NMT introduces', () => {
+  const m = pageTranslation.match(/const markerRe = (\/.+\/[a-z]*);/);
+  assert.ok(m, 'markerRe is no longer declared in the shape this test reads');
+  const re = new RegExp(m[1].slice(1, m[1].lastIndexOf('/')), m[1].slice(m[1].lastIndexOf('/') + 1));
+  // 实测 en→zh-Hans 的产物
+  assert.match('阅读<A1>角色向量论文</a1>了解更多详情。', re, 'an uppercased opener must still parse');
+  // 宽容一点，免得多一个空格就把链接丢了
+  assert.match('请阅读< a1 >文档</ a1 >。', re, 'injected whitespace must still parse');
+});
+
+test('the reader-facing strip is the narrow one, the analysis strips are the broad one', () => {
+  // 渲染路径（buildTranslationContent 的 emit、受管容器的 ::after）只能用
+  // markupDebrisRe；用笼统正则就会删掉页面正文里本来就有的 <b2>。
+  const build = pageTranslation.slice(pageTranslation.indexOf('function buildTranslationContent'));
+  // 注释里提名字是可以的，这里要看的是代码里真的用了哪条
+  const body = build.slice(0, build.indexOf('\n  // 向后兼容的旧签名'))
+    .replace(/^\s*\/\/.*$/gm, '');
+  assert.match(body, /markupDebrisRe\(markupElements\)/,
+    'buildTranslationContent no longer scrubs debris before rendering');
+  assert.doesNotMatch(body, /MARKUP_MARKER_RE/,
+    'the render path must not use the broad regex — it eats the page\'s own prose');
+
+  const managed = pageTranslation.slice(pageTranslation.indexOf('ctx.renderManagedTranslation(') - 700,
+    pageTranslation.indexOf('ctx.renderManagedTranslation(') + 200);
+  assert.match(managed, /markupDebrisRe\(block\.markupElements\)/,
+    'the managed ::after path fell back to the broad regex');
+});
+
+test('markupDebrisRe only ever names tags and numbers this block handed out', () => {
+  const src = pageTranslation.match(/function markupDebrisRe[\s\S]+?\n  }/)[0];
+  const markupDebrisRe = new Function(`${src}; return markupDebrisRe;`)();
+
+  // 本块发出去的是 a1 和 strong2
+  const re = markupDebrisRe([{ tag: 'a', index: 1 }, { tag: 'strong', index: 2 }]);
+  const scrub = (s) => s.replace(new RegExp(re.source, re.flags), '');
+
+  // 自己的字：发过的标签名 + 发过的编号，无论怎么串、什么大小写、夹不夹空格
+  assert.equal(scrub('请阅读<a1>文档</a1>。'), '请阅读文档。');
+  assert.equal(scrub('请阅读<A1>文档</a1>。'), '请阅读文档。');
+  assert.equal(scrub('请阅读< a1 >文档</ a1 >。'), '请阅读文档。');
+  assert.equal(scrub('串错了的<strong1>也是残骸'), '串错了的也是残骸');
+
+  // 页面自己的字：没发过 b，也没发过 9，一个都不能动
+  assert.equal(scrub('HTML 里 <b9> 是什么意思？'), 'HTML 里 <b9> 是什么意思？');
+  assert.equal(scrub('<div1> 不在标记集里'), '<div1> 不在标记集里');
+
+  assert.equal(markupDebrisRe([]), null, 'no markers issued → nothing to scrub');
+  assert.equal(markupDebrisRe(null), null);
+});


### PR DESCRIPTION
## Background
- This PR packages the current branch changes for review.
- It groups the current branch updates into one reviewable change.

## Solution
- fix: preserve links on the default engine, and drop translations the page has no room for

## Affected Files
- `content/content-fit-guard.js`
- `content/content-language.js`
- `content/content-page-translation.js`
- `manifest.json`
- `test/e2e/markup-preservation.spec.js`
- `test/unit/clip-guard.test.mjs`
- `test/unit/fit-guard.test.mjs`
- `test/unit/markup-marker-regex.test.mjs`