### PR TITLE
fix: keep the translation and yield the source when a block holds only o

### DIFF
--- a/content/content-fit-guard.js
+++ b/content/content-fit-guard.js
@@ -15,43 +15,119 @@
 // 这些格子不会为多出来的一行长高，相邻格子只隔十来像素，译文于是直接压在下一行
 // 原文上。
 //
+// ---------------------------------------------------------------------------
+// 一、装不下的时候做什么：**先让原文，让不动才撤**
+//
+// 「这个框装不下原文和译文」不等于「这个框装不下译文」。它装得下其中一个——原文
+// 本来就在里面待着。撤掉译文，用户在这一块什么都没得到；让出原文，用户读到的正是
+// 他要的那一行。所以顺序是：先请原文让位（content-page-translation.js 的
+// hideCrowdedSource），重新量一次，还是站不住才撤译文。
+//
+// 让原文只走「加一个类名」那条路（safeOnly）。「仅显示译文」模式还有一条把原文子
+// 节点包进 wrap 的路，那条会搬页面自己的节点，框架重渲染时可能出问题——那个模式默
+// 认关、由用户显式打开，风险是他选的；这里是默认行为，不能把同样的风险变成所有人
+// 的默认。包不进去就撤译文，那条路一个页面节点都不动。
+//
+// ---------------------------------------------------------------------------
+// 二、量谁：**量「原文 + 译文」这一对的并集**
+//
+// 只量译文自己的矩形会漏掉一整类：框不长高，但它把**原文**从另一头顶出去。
+// transformer-explainer 顶部那个 .title 是 `display:flex; justify-content:end`、
+// 高 80px 写死，内容贴着底边排——插一行译文，译文稳稳待在框底，被顶出框顶的是原文
+// 「Multi-head Self Attention」，往上跑 28px 撞进上一行的「Transformer Block 1」。
+// 译文相对宿主一点没溢出，只量译文永远量不到。这个框现在要装下的是两个人，就得按
+// 两个人量。
+//
+// 译文插在原文**里面**（水平 flex / 表格单元格 / slot）时，原文的矩形已经含着译文，
+// 并集就是原文自己——正好是该量的那个。
+//
+// ---------------------------------------------------------------------------
+// 三、还有一种框：**原文块自己的盒子就装不下自己的字**
+//
+// 顶栏的 Temperature / Sampling / Probabilities 是三个 clientHeight 为 0 的 div，
+// 字画在盒子外面。盒子没有高度，挨着它摆的任何东西都落在同一个 y 上——译文「温度」
+// 直接盖在「Temperature」身上，糊成「温度perature」。这跟溢出宿主是两码事：宿主
+// 好好的，是原文块自己在撒谎。判据 `scrollHeight > clientHeight`（在原文块上量，
+// 译文不是它的子节点时才作数）——它自己的字都超出了自己的盒子，那么以这个盒子为
+// 参照放译文必然重叠。
+//
+// ---------------------------------------------------------------------------
+// 四、横向：**这一块比页面原本给它的地方宽了**
+//
+// 上面三条都是纵向的。剩下一类是横着的：右侧那一列
+// 「11 more identical Transformer Blocks」的容器是 width 收缩包裹的，英文在 112px
+// 里排成三行，中文一行排下来把整个容器撑到 147px，右边缘直接顶进隔壁「概率」那一
+// 列。译文相对自己的宿主一点没溢出——宿主自己变宽了，所以前三条一条都够不着。
+//
+// **变宽本身不是问题**：正常流里的收缩包裹框（表格单元格、按钮、inline-block）变宽，
+// 邻居会被推开，页面重新排一遍就好了。出了流的框（position:absolute/fixed）不会——
+// 它是按坐标摆的，长出来的那一截推不开谁，只能盖上去。判据就是这两个条件的合取：
+// 原文块比插译文之前宽了，且两层之内有出了流的祖先。
+//
+// 「插译文之前有多宽」量不出来，只能记：insertTranslationBlock 在插之前现场量一次
+// 原文块的宽度，作为第二个参数传进来。不传就跳过这条（悬停/划词那条路不走这里）。
+//
+// 量的是**原文块自己**，不是「原文 + 译文」的并集——这一条跟第二节相反，那里的理由
+// 在这里不成立。并集会把另一码事算进来：译文继承了原文的 `position:absolute`，刚被
+// keepInFlow 按回 static，于是从一个 206px 的「跳到主要内容」摊成整行 1585px，并集
+// 一下子宽了 1482px。可框一点没变宽，谁也没挤到，撤它纯属白撤（Anthropic 那篇的两
+// 条跳转链接就是这么被误伤的）。收缩包裹的框被译文撑开时，里面的原文块会跟着变宽
+// ——那才是「页面给的地方不够了」。
+//
+// 收场跟前三条不同：**直接撤，不先让原文**。前三条让原文有用，是因为框里挤的是两个
+// 人；这里把框撑宽的正是译文自己，原文让开框还是那么宽。夹 max-width 让它折回列里
+// 也试过，不行：这一块的 white-space 是 pre，字根本不换行，夹完盒子是窄了，字照样
+// 画在外面——几何上「修好了」，看上去一模一样。
+//
+// ---------------------------------------------------------------------------
 // 量法（下面所有数字都是这一套，换算法就不可比了）：只数**看得见**的矩形
 // （checkVisibility，含 opacity/visibility），互相包含的不算，横竖都压过 6px 才算
 // 一处；页面自己本来就有的重叠在插译文**之前**先量一遍，最后相减。译文按它自己那
 // 个容器算一个矩形——不能拆成里面的 <a>/<span> 叶子，否则「保留内联标记」一开，
-// 被数的矩形集合就变了，开关前后的数字对不上。
+// 被数的矩形集合就变了，开关前后的数字对不上。另外两条修正，都是为了别把页面本来
+// 的样子算成我们的账：
+//   - 逐层与裁剪祖先的 padding box 求交，交空的不算——轮播里 20 张幻灯片全在 DOM
+//     里、checkVisibility 全说可见，其实被 overflow:hidden 的轨道裁在框外。
+//   - 相交区中心做命中测试，往上找第一个不透明背景：它同时罩着两者才算真糊了。
+//     那张卡片是一块不透明浮层，它盖住下面的概率列表是页面自己的设计。
 //
-// transformer-explainer 整页 301 块，同一套量法：
+// 三个页面，同一套量法，同一轮跑出来的（off = 这个文件不存在时的行为；旧 = 只量译
+// 文矩形、溢出就撤、不让原文；新 = 上面四条）。transformer-explainer 自己是动态的，
+// 每次跑块数在 299–301 之间，「留下/让/撤」三列的绝对数跟着浮动几个，最右那列稳定：
 //
-//   fit guard 关（今天线上的行为）  译文全留 300 条，新增重叠 17
-//   fit guard 开                    留 221 条、撤 79 条，新增重叠 5
+//   页面                块数   策略   译文留下   让原文   撤掉   新增重叠
+//   transformer-expl.    301   off      301        0        0       5
+//                              旧       216        0       85       2
+//                              新       225       17       76       0
+//   Anthropic 长文       155   off      155        0        0       6
+//                              旧       153        0        2       1
+//                              新       155        3        0       1
+//   维基百科(翻头 400)  ~3000  off      400        0        0      17
+//                              旧       393        0        7       1
+//                              新       393        1        7       1
 //
-// 剩下那 5 处全在顶部控件栏，而且都是**横向**相撞：那些容器是 w-max，译文一挂上去
-// 它就跟着变宽，相对宿主根本没溢出，被撞的是坐标定死的隔壁控件。这里的判据是相对
-// 宿主的纵向溢出，够不着这一类——要接住得改成邻居碰撞检测，那是另一套机制和另一份
-// 风险预算，没有塞进这次改动。
+// 新判据在三个页面上都不比旧的差，代价花在该花的地方：transformer 这种坐标画出来的
+// 页面上新增重叠归零（旧判据剩 2 处），Anthropic 这种正常长文上一条译文都不用撤
+// （旧判据撤 2 条）。维基百科两者打平——「让原文」只发生 1 次、撤 7 条，也就是说这
+// 条默认行为不会在普通文章上乱动原文，这正是要守住的边界。
 //
-// 维基百科（Transformer 词条，翻头 400 块，页面自带 60 处重叠）同一套量法：
+// 还有一个数字不在表里，但它是这次改动的由头：transformer 那张
+// 「Transformer 是现代 AI 的核心架构」卡片，旧判据把整段正文的译文撤掉了、只剩标题
+// （cardKept: false），新判据留下了。撤译文当成第一手段的代价就长这样——量出来是
+// 「新增重叠 2」，看上去是一整张卡片没翻译。
 //
-//   fit guard 关，标记开   译文全留 400 条，新增重叠 42
-//   fit guard 开，标记开   留 395 条，新增重叠 31（超链接重建 383 条）
-//   fit guard 开，标记关   留 395 条，新增重叠 32（超链接 0 条）
+// 这三页跑的都是同一个量法，但页面自己会变：维基百科这一轮的 baseline 是 561（上一
+// 轮某次是 53，条目折叠状态不同），所以只有同一轮之间的数才可比，换一天重测要三种
+// 策略一起重跑。
 //
-// 两处结论一致：**保留内联标记对重叠是中性的**（31 对 32、5 对 5，都在噪声里），
-// fit guard 两边都在减（42→31、17→5）。维基剩下的 31 是往一篇本来就密的长文里塞
-// 400 段字的固有代价，不是这两个改动引进来的。
-//
-// 判据是纯几何的，不看类名也不看站点：**译文的矩形跑到了紧挨着它的祖先的 padding
-// box 外面**。框只要肯为它长高，译文就还在框里；跑出去了，就说明这个框的高度是外面
-// 定死的，页面没打算给这行字留地方。站不住就把译文撤掉——原文一个字不动，比压上去
-// 糊成一团强。
-//
-// 溢出之后还要再问一句这算什么，答案在这个框裁不裁剪：
+// ---------------------------------------------------------------------------
+// 判据是纯几何的，不看类名也不看站点。溢出之后还要再问一句这算什么，答案在这个框
+// 裁不裁剪：
 //   - 会裁（hidden/clip/auto/scroll）→ 框外那截根本不画出来，压不到谁。那是
 //     clip-guard 管的「看不见」或者滚动条管的事，不是这里管的「盖住」，在那儿撤译文
 //     只会把它们已经处理好的情况弄砸。既然这一层就裁住了，再往上也溢不出去，所以直
 //     接收工。
-//   - 不裁（visible）→ 框外那截照样画出来，正压在别人身上。撤掉。
+//   - 不裁（visible）→ 框外那截照样画出来，正压在别人身上。让原文，让不动就撤。
 // 反过来，**装得下译文的裁剪框在这里没有任何特权**：它裁不掉任何东西，谁也没保护，
 // 只是自己变大了去挤别人。transformer-explainer 的 span.label.float 就是这样一个
 // 框——39px 高、绝对定位、稳稳装下译文，然后整个盖在隔壁的 2px 格子上。所以顺序是
@@ -63,7 +139,8 @@
 // **只看紧挨着的两层**（MAX_DEPTH）。约束一行字的框总是贴着它的——格子、单元格、
 // 按钮；再往上是页面骨架，那些框的高度不是冲着这行字来的，它们自己的内容本来就可能
 // 溢出（维基百科的 .mw-collapsible 侧栏、footer、tbody 都是），拿几何判据去量只会把
-// 页面自己的老溢出算到译文头上。实测这一个常数就是全部代价所在，同一套代码：
+// 页面自己的老溢出算到译文头上。实测这一个常数就是全部代价所在，同一套代码（这张表
+// 是另一轮跑的，维基百科当时的条目折叠状态跟上表不同——只跟它自己这四行比）：
 //
 //   MAX_DEPTH  transformer 新增重叠   维基百科撤掉的译文
 //     1              24                   5 / 1383
@@ -97,6 +174,43 @@
     }
   }
 
+  // 这条译文配对的原文块。译文要么是它的下一个兄弟（常规段落），要么插在它
+  // 里面（水平 flex / 表格单元格 / slot）。
+  function pairedSource(translationEl) {
+    const prev = translationEl.previousElementSibling;
+    if (prev && prev.classList && prev.classList.contains('ai-translator-translated')) return prev;
+    const parent = translationEl.parentElement;
+    return parent ? parent.closest('.ai-translator-translated') : null;
+  }
+
+  // 「原文 + 译文」这一对占的范围——为什么不能只量译文，见文件头第二节。
+  function unionRect(translationEl) {
+    const rect = translationEl.getBoundingClientRect();
+    const source = pairedSource(translationEl);
+    if (!source) return rect;
+    const sourceRect = source.getBoundingClientRect();
+    // 原文已经让出去了（display:none），这一对现在只剩译文
+    if (sourceRect.width === 0 && sourceRect.height === 0) return rect;
+    // 译文插在原文里面：原文的矩形已经含着译文
+    if (source.contains(translationEl)) return sourceRect;
+    return {
+      top: Math.min(rect.top, sourceRect.top),
+      bottom: Math.max(rect.bottom, sourceRect.bottom),
+    };
+  }
+
+  // 祖先里有没有出了流的框。出了流 = 按坐标摆的：它长宽了推不开谁，只能盖上去。
+  // 正常流里的收缩包裹框（表格单元格、按钮、inline-block）变宽是无害的，邻居会让开。
+  function hasOutOfFlowAncestor(el) {
+    let n = el.parentElement;
+    for (let depth = 0; depth < MAX_DEPTH && n && n !== document.body && n !== document.documentElement; depth++) {
+      const position = window.getComputedStyle(n).position;
+      if (position === 'absolute' || position === 'fixed') return true;
+      n = n.parentElement;
+    }
+    return false;
+  }
+
   // rect 有没有跑到 host 的 padding box 外面。
   // 用 clientTop/clientHeight 而不是 rect.height：溢出发生在 padding box 上，
   // 而 getBoundingClientRect() 含边框。与 clip-guard 的 clipsAway 同一套量法。
@@ -107,15 +221,32 @@
     return rect.bottom > bottom + SLACK || rect.top < top - SLACK;
   }
 
+  // 撤掉这条译文。撤之前一定要把原文放回去——不管是刚才为这条译文让的，还是
+  // 「仅显示译文」模式藏的。译文没了还藏着原文，那一块两种语言都没有，比重叠糟得多。
+  function dropTranslation(translationEl) {
+    if (ctx.releaseSourceForTranslation) ctx.releaseSourceForTranslation(translationEl);
+    translationEl.remove();
+    if (ctx.releaseTranslationClipGuards) ctx.releaseTranslationClipGuards();
+    return false;
+  }
+
+  // 站不住的收场：先请原文让位，重新量一次还站不住才撤。
+  function yieldOrDrop(translationEl, stillSpills) {
+    if (ctx.hideCrowdedSource && ctx.hideCrowdedSource(translationEl) && !stillSpills()) return true;
+    return dropTranslation(translationEl);
+  }
+
   /**
-   * 确认页面确实给了这条译文站的地方；站不住就把它撤掉。
+   * 确认页面确实给了这条译文站的地方；站不住就先让原文，让不动才把译文撤掉。
    * 必须在 keepTranslationVisible() 之后调用——clip guard 可能刚把某个祖先的
    * max-height 放开，那之后框才是它最终的样子。
    *
    * @param {Element} translationEl 刚插进 DOM 的译文节点
+   * @param {number} [sourceWidthBefore] 插译文之前原文块的宽度，插入方现场量的
+   *   （见文件头第四节）。不传就跳过横向那条判据。
    * @returns {boolean} 译文是否留下了
    */
-  ctx.keepTranslationInFlow = function(translationEl) {
+  ctx.keepTranslationInFlow = function(translationEl, sourceWidthBefore) {
     if (!translationEl || translationEl.nodeType !== Node.ELEMENT_NODE || !translationEl.isConnected) {
       return false;
     }
@@ -126,19 +257,40 @@
     // 没有尺寸的译文量不出溢出（还没排版，或者本来就是空的），留着。
     if (rect.width === 0 && rect.height === 0) return true;
 
+    // 原文块自己的盒子就装不下自己的字（见文件头第三节）。这跟溢出宿主无关，
+    // 是原文块的几何在撒谎，以它为参照摆任何东西都会落在那些字上面。
+    // 译文是它的子节点时 scrollHeight 把译文也算进去了，那一路量不出这件事，跳过。
+    const source = pairedSource(translationEl);
+    if (source && !source.contains(translationEl) && source.textContent.trim() &&
+        source.scrollHeight > source.clientHeight + SLACK) {
+      // 这里没有「让了还是不行」的可能：压的就是原文那几个字，原文让开就没了。
+      return yieldOrDrop(translationEl, () => false);
+    }
+
+    // 横向：这一块比页面原本给它的地方**宽**了（见文件头第四节）。
+    // 量的是原文块自己的宽度，不是这一对的并集：收缩包裹的框被译文撑开，里面的
+    // 原文块跟着变宽，这就是「页面给的地方不够了」的信号。并集会把另一码事算进来
+    // ——译文继承了原文的 absolute，刚被 keepInFlow 按回 static，于是从一个 206px
+    // 的跳转链接摊成整行 1585px。框一点没变宽，谁也没挤到。
+    if (sourceWidthBefore > 0 && source && hasOutOfFlowAncestor(translationEl) &&
+        source.getBoundingClientRect().width > sourceWidthBefore + SLACK) {
+      // 这里没有「先让原文」那一步：把框撑宽的正是译文，原文让开框还是那么宽。
+      return dropTranslation(translationEl);
+    }
+
     let host = translationEl.parentElement;
     for (let depth = 0; depth < MAX_DEPTH && host && host !== document.body && host !== document.documentElement; depth++) {
       // 内联盒没有自己的高度（clientHeight 恒为 0），量它得到的溢出是假的
-      if (host.clientHeight > 0 && spillsOut(host, rect)) {
+      if (host.clientHeight > 0 && spillsOut(host, unionRect(translationEl))) {
         // 溢出了。这一下究竟是「看不见」还是「盖住别人」，取决于这个框裁不裁剪：
         //   - 会裁（hidden/clip/auto/scroll）→ 框外那截根本不显示，压不到谁。
         //     滚动条或者 clip-guard 会处理，撤译文只会把它们处理好的情况弄砸。
         //     而且既然这一层就裁住了，再往上也溢不出去，所以是 return。
-        //   - 不裁（visible）→ 框外那截照样画出来，正压在别人身上。撤掉。
+        //   - 不裁（visible）→ 框外那截照样画出来，正压在别人身上。
         if (window.getComputedStyle(host).overflowY !== 'visible') return true;
-        translationEl.remove();
-        if (ctx.releaseTranslationClipGuards) ctx.releaseTranslationClipGuards();
-        return false;
+        const constrainingHost = host;
+        return yieldOrDrop(translationEl,
+          () => spillsOut(constrainingHost, unionRect(translationEl)));
       }
       // 装得下 → 这一层不是约束，接着往上。注意会裁剪的框在这里没有特权：一个装得
       // 下译文的 overflow:hidden 框裁不掉任何东西，它谁也没保护，只是自己去挤别人

--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -316,13 +316,29 @@
     applyTranslationOnlyMode();
   }
 
-  // ==================== 仅显示译文 ====================
-  // settings.showTranslationOnly（默认关）：整页翻译插入译文后隐藏对应原文。
+  // ==================== 隐藏原文 ====================
+  // 隐藏一条译文对应的原文，有两个互不相干的理由：
+  //
+  //   1. settings.showTranslationOnly（默认关）——用户要的，全页一刀切。
+  //   2. 这一块挤不下两种语言（content-fit-guard.js 判的）——页面逼的，逐块决定。
+  //      译文节点上带 data-ai-translator-crowded 标记。
+  //
+  // 两个理由共用一套隐藏/释放机制，但**该不该藏是逐条算的**，不能再看一个全局开关：
+  // 「仅显示译文」关掉时，crowded 那批必须继续藏着，否则挤不下的那些块又糊回去。
   // 只作用于整页翻译（.ai-translator-translated 标记的块）；悬停/划词翻译的
   // 译文块（带各自的类名）被明确排除。
+  const CROWDED_ATTR = 'data-ai-translator-crowded';
+  const PAGE_TRANSLATION_SELECTOR =
+    '.ai-translator-inline-block:not(.ai-translator-selection-translation):not(.ai-translator-hover-translation)';
+
+  function shouldHideSource(translationEl) {
+    // 浮球“隐藏译文”开关优先：译文都不显示了还藏着原文，页面就两边全空了
+    if (state.translationsVisible === false) return false;
+    if (settings.showTranslationOnly) return true;
+    return translationEl.hasAttribute(CROWDED_ATTR);
+  }
 
   function isTranslationOnlyActive() {
-    // 浮球“隐藏译文”开关优先：译文都不显示了还藏着原文，页面就两边全空了
     return !!settings.showTranslationOnly && state.translationsVisible !== false;
   }
 
@@ -335,18 +351,23 @@
   // 子树时可能因找不到原父节点而报错。隔离世界里看不到页面世界的
   // __reactFiber$ 等 expando，无法预检测；本模式默认关、由用户显式打开，
   // 遇到这类页面关掉开关即可完整恢复。
-  function hideSourceForTranslation(translationEl) {
+  // @param {{safeOnly?: boolean}} [options] safeOnly：只走加类名那条路，不碰 wrap。
+  //   crowded 隐藏是默认行为（用户没打开任何开关），不能顺带把搬节点的风险也变成
+  //   默认——包不进去就让 fit guard 撤译文，那条路一个页面节点都不动。
+  // @returns {boolean} 原文是否藏起来了
+  function hideSourceForTranslation(translationEl, options) {
     const prev = translationEl.previousElementSibling;
     if (prev && prev.classList && prev.classList.contains('ai-translator-translated')) {
       prev.classList.add('ai-translator-source-hidden');
-      return;
+      return true;
     }
+    if (options && options.safeOnly) return false;
 
     const holder = translationEl.parentElement;
     const host = holder && holder.closest('.ai-translator-translated');
-    if (!host) return;
+    if (!host) return false;
     // 受管容器：译文是原文块自己的 ::after，隐藏原文会连译文一起消失，只能共存
-    if (ctx.isInsideManagedDomRoot && ctx.isInsideManagedDomRoot(host)) return;
+    if (ctx.isInsideManagedDomRoot && ctx.isInsideManagedDomRoot(host)) return false;
 
     let wrap = holder.querySelector(':scope > .ai-translator-source-wrap');
     for (const node of Array.from(holder.childNodes)) {
@@ -364,45 +385,70 @@
       wrap.appendChild(node);
     }
     if (wrap) wrap.classList.add('ai-translator-source-hidden');
+    return !!wrap;
   }
 
-  // 按当前开关状态应用/撤销“仅显示译文”。设置变化、浮球“隐藏译文”切换、
-  // revealHiddenTranslations 时都会调用，幂等。
+  // 找一条隐藏原文配对的译文。隐藏原文有两种形态，配对方向相反：
+  // 加了类名的原文块 → 译文是它的下一个兄弟；wrap → 译文是 wrap 的兄弟。
+  function pairedTranslation(hiddenEl) {
+    const candidate = hiddenEl.classList.contains('ai-translator-source-wrap')
+      ? hiddenEl.parentElement && hiddenEl.parentElement.querySelector(':scope > .ai-translator-inline-block')
+      : hiddenEl.nextElementSibling;
+    return candidate && candidate.classList
+      && candidate.classList.contains('ai-translator-inline-block') ? candidate : null;
+  }
+
+  function releaseHiddenSource(hiddenEl) {
+    hiddenEl.classList.remove('ai-translator-source-hidden');
+    if (!hiddenEl.classList.contains('ai-translator-source-wrap')) return;
+    const parent = hiddenEl.parentNode;
+    if (!parent) return;
+    while (hiddenEl.firstChild) parent.insertBefore(hiddenEl.firstChild, hiddenEl);
+    hiddenEl.remove();
+  }
+
+  // 重新算一遍每条原文该不该藏。设置变化、浮球“隐藏译文”切换、
+  // revealHiddenTranslations、fit guard 撤译文时都会调用，幂等。
+  //
+  // 先全量释放再重新隐藏，而不是分「模式开/模式关」两条路：现在藏原文的理由不止一
+  // 个（见 shouldHideSource），逐条问一次是唯一不会把两个理由搞混的写法。释放这一
+  // 遍同时修掉页面脚本删掉译文之后留下的孤儿原文——译文没了原文不能跟着陪葬。
   function applyTranslationOnlyMode() {
-    if (isTranslationOnlyActive()) {
-      // 页面脚本可能删掉我们插入的译文，原文不能跟着陪葬：先把配对译文已经
-      // 不在的隐藏原文放回来，再按当前还活着的译文重新隐藏。
-      document.querySelectorAll('.ai-translator-source-hidden').forEach((el) => {
-        if (el.classList.contains('ai-translator-source-wrap')) {
-          const holder = el.parentElement;
-          if (holder && holder.querySelector(':scope > .ai-translator-inline-block')) return;
-          el.classList.remove('ai-translator-source-hidden');
-          if (holder) {
-            while (el.firstChild) holder.insertBefore(el.firstChild, el);
-            el.remove();
-          }
-        } else {
-          const next = el.nextElementSibling;
-          if (!next || !next.classList || !next.classList.contains('ai-translator-inline-block')) {
-            el.classList.remove('ai-translator-source-hidden');
-          }
-        }
-      });
-      const translations = document.querySelectorAll(
-        '.ai-translator-inline-block:not(.ai-translator-selection-translation):not(.ai-translator-hover-translation)'
-      );
-      translations.forEach((el) => hideSourceForTranslation(el));
-    } else {
-      document.querySelectorAll('.ai-translator-source-hidden').forEach((el) => {
-        el.classList.remove('ai-translator-source-hidden');
-      });
-      document.querySelectorAll('.ai-translator-source-wrap').forEach((wrap) => {
-        const parent = wrap.parentNode;
-        if (!parent) return;
-        while (wrap.firstChild) parent.insertBefore(wrap.firstChild, wrap);
-        wrap.remove();
-      });
+    document.querySelectorAll('.ai-translator-source-hidden').forEach((el) => {
+      const translation = pairedTranslation(el);
+      if (translation && shouldHideSource(translation)) return;
+      releaseHiddenSource(el);
+    });
+    // 释放之后还剩下的 wrap 是上一轮留下的空壳，原样解包，不给页面留多余结构
+    document.querySelectorAll('.ai-translator-source-wrap:not(.ai-translator-source-hidden)')
+      .forEach((wrap) => releaseHiddenSource(wrap));
+
+    document.querySelectorAll(PAGE_TRANSLATION_SELECTOR).forEach((el) => {
+      if (shouldHideSource(el)) hideSourceForTranslation(el);
+    });
+  }
+
+  // fit guard 判定这一块挤不下两种语言时调用：给译文打上 crowded 标记，把原文让出来。
+  // 只走加类名那条安全路（见 hideSourceForTranslation 的 safeOnly）。
+  // @returns {boolean} 让出来了没有；没让出来的话 fit guard 会撤掉译文
+  function hideCrowdedSource(translationEl) {
+    if (!hideSourceForTranslation(translationEl, { safeOnly: true })) return false;
+    translationEl.setAttribute(CROWDED_ATTR, '');
+    return true;
+  }
+
+  // fit guard 要撤掉这条译文了：先把为它让出来的原文放回去。两个理由藏的都要放
+  // ——译文没了还藏着原文，那一块彻底空白，比重叠糟得多。
+  function releaseSourceForTranslation(translationEl) {
+    translationEl.removeAttribute(CROWDED_ATTR);
+    const prev = translationEl.previousElementSibling;
+    if (prev && prev.classList && prev.classList.contains('ai-translator-source-hidden')) {
+      releaseHiddenSource(prev);
+      return;
     }
+    const holder = translationEl.parentElement;
+    const wrap = holder && holder.querySelector(':scope > .ai-translator-source-wrap');
+    if (wrap) releaseHiddenSource(wrap);
   }
 
   function estimateTokens(text) {
@@ -1556,10 +1602,15 @@
   //
   // 下面每一处把译文放进 DOM 的分支后面都要跟一次，clip-guard.test.mjs 会数：
   // 插入点比检查点多，就是漏了一处。
-  function finishTranslationInsert(translationEl) {
+  // @param {number} sourceWidthBefore 插译文之前原文块的宽度。fit guard 的横向判据
+  //   要「页面原本给这一块多少地方」，插完就量不到了，只能在插之前记下来传进去。
+  function finishTranslationInsert(translationEl, sourceWidthBefore) {
     keepTranslationVisible(translationEl);
-    if (ctx.keepTranslationInFlow && !ctx.keepTranslationInFlow(translationEl)) return false;
+    // 「仅显示译文」开着时先藏原文再交给 fit guard：框里只剩译文一个人，量出来的
+    // 才是它真实的处境。反过来先量就会按「原文 + 译文」的高度白撤一批译文。
     if (isTranslationOnlyActive()) hideSourceForTranslation(translationEl);
+    if (ctx.keepTranslationInFlow &&
+        !ctx.keepTranslationInFlow(translationEl, sourceWidthBefore)) return false;
     return true;
   }
 
@@ -1599,6 +1650,10 @@
       keepTranslationVisible(element);
       return;
     }
+
+    // 页面原本给这一块多少横向空间。插完就问不到了（收缩包裹的框会被译文自己撑宽），
+    // fit guard 的横向判据要的就是这个数，所以在动 DOM 之前量。
+    const sourceWidthBefore = element.getBoundingClientRect().width;
 
     // 检测是否在水平布局中
     const isHorizontalFlex = isHorizontalFlexParent(element);
@@ -1645,7 +1700,7 @@
 
       // 将翻译作为子元素追加到原元素内部（显示在原文右侧）
       inlineTarget.appendChild(translationEl);
-      finishTranslationInsert(translationEl);
+      finishTranslationInsert(translationEl, sourceWidthBefore);
     } else {
       // 对于非水平 flex 布局（如侧边栏），插入为同级元素
       // 表格单元格例外：译文要插到单元格【内部】，插一个兄弟 <td> 会给整行多加一列、撑破表格网格
@@ -1718,16 +1773,16 @@
           box-sizing: border-box;
         `;
         element.appendChild(internalTranslation);
-        finishTranslationInsert(internalTranslation);
+        finishTranslationInsert(internalTranslation, sourceWidthBefore);
       } else if (isTableCell) {
         // 表格单元格：译文作为块级子节点追加到单元格【内部】，显示在原内容下方，保持网格不变。
         // 用 <div>（而非 <td>）避免 td 内嵌 td 的非法结构。
         element.appendChild(translationEl);
-        finishTranslationInsert(translationEl);
+        finishTranslationInsert(translationEl, sourceWidthBefore);
       } else {
         // 插入到原元素后面
         element.after(translationEl);
-        finishTranslationInsert(translationEl);
+        finishTranslationInsert(translationEl, sourceWidthBefore);
       }
     }
   }
@@ -2078,6 +2133,9 @@
   ctx.buildTranslationContentWithMath = buildTranslationContentWithMath;
   ctx.buildTranslationContent = buildTranslationContent;
   ctx.applyTranslationOnlyMode = applyTranslationOnlyMode;
+  // content-fit-guard.js 用：挤不下两种语言时让原文，撤译文时把原文放回来
+  ctx.hideCrowdedSource = hideCrowdedSource;
+  ctx.releaseSourceForTranslation = releaseSourceForTranslation;
   // 内联格式标记的唯一定义，content-language.js 剥标记时复用
   ctx.MARKUP_MARKER_RE = MARKUP_MARKER_RE;
   ctx.isMathElement = isMathElement;

--- a/test/unit/clip-guard.test.mjs
+++ b/test/unit/clip-guard.test.mjs
@@ -283,8 +283,13 @@ test('the post-insert helper runs both guards, and in the order that matters', (
   // clip guard 可能把某个祖先的 max-height 放开，框因此长高 —— fit guard 要量的是
   // 放开之后的样子，所以它必须在后面
   assert.ok(clip < fit, 'the fit guard must measure the box the clip guard just relaxed');
-  // 顺序反了会出现最糟的结果：原文被藏起来，译文又被撤走，那一块彻底空白
-  assert.ok(fit < hide, 'the source must not be hidden until the translation is known to survive');
+  // 「仅显示译文」开着时也一样：原文已经不显示了，框里只剩译文一个人，fit guard
+  // 量的必须是这个样子，否则会按「原文 + 译文」的高度白撤一批译文。撤译文那条路
+  // 自己负责把原文放回去（content-fit-guard.js 的 yieldOrDrop），所以先藏不会留下
+  // 两种语言都没有的块。
+  assert.ok(hide < fit, 'the fit guard must measure the box translation-only mode just emptied');
+  assert.match(repoFile('content/content-fit-guard.js'), /releaseSourceForTranslation\(translationEl\);\s*\n\s*translationEl\.remove\(\)/,
+    'the fit guard drops a translation without putting its source back — that block ends up blank');
 });
 
 test('the hover path asks the guard when it tracks a translation', () => {

--- a/test/unit/fit-guard.test.mjs
+++ b/test/unit/fit-guard.test.mjs
@@ -14,13 +14,16 @@
 //   .textbook-tooltip clientHeight 5px,  scrollHeight 11px
 //   .type-btn         clientHeight 17px, scrollHeight 41px once a translation is in
 //
-// 301 blocks, 22 newly introduced *visible* overlaps (baseline-controlled: the
+// 301 blocks, 5 newly introduced *visible* overlaps (baseline-controlled: the
 // page's own overlaps measured before injection and subtracted). With the guard,
-// 2.
+// 0 — and 225 of the 301 translations survive, because a block that cannot hold
+// two languages still holds one: the source yields and the translation stays.
+// The full three-page comparison is in the guard's own header.
 //
 // Exercised for real against a fake element tree rather than grepped for: what
-// has to stay true is behavioural — a translation with nowhere to go is removed,
-// one that fits is left alone, and a clipping ancestor is never second-guessed.
+// has to stay true is behavioural — a translation with nowhere to go takes the
+// source's place, one that fits is left alone, a clipping ancestor is never
+// second-guessed, and a block never ends up with neither language in it.
 //
 // Run with: npm run test:unit
 import test from 'node:test';
@@ -28,7 +31,7 @@ import assert from 'node:assert/strict';
 
 // ---------------------------------------------------------------------------
 // A fake DOM, deep enough for the guard's questions: where is this box, how tall
-// is it, does it clip, and what is my translation's rect.
+// is it, does it clip, where is my paired source, and what is my rect.
 // ---------------------------------------------------------------------------
 
 class FakeStyle {
@@ -39,18 +42,32 @@ class FakeStyle {
   removeProperty(name) { this.props.delete(name); }
 }
 
+class FakeClassList {
+  constructor(...names) { this.names = new Set(names); }
+  add(name) { this.names.add(name); }
+  remove(name) { this.names.delete(name); }
+  contains(name) { return this.names.has(name); }
+}
+
 class FakeElement {
-  constructor({ top = 0, height = 0, overflowY = 'visible', position = 'static' } = {}) {
+  constructor({ top = 0, height = 0, width = 100, overflowY = 'visible', position = 'static',
+    classes = [], text = '', scrollHeight = null } = {}) {
     this.nodeType = 1;
     this.isConnected = true;
     this.parentElement = null;
     this.children = [];
     this.style = new FakeStyle();
+    this.classList = new FakeClassList(...classes);
+    this.attributes = new Set();
     this.clientTop = 0;
+    this.hidden = false;   // 让出原文 = display:none，矩形塌成 0
     this.top = top;
     this.height = height;
+    this.width = width;
     this.overflowY = overflowY;
     this.position = position;
+    this.textContent = text;
+    this.ownScrollHeight = scrollHeight;
   }
 
   append(child) { child.parentElement = this; this.children.push(child); return child; }
@@ -63,11 +80,35 @@ class FakeElement {
     this.isConnected = false;
   }
 
+  get previousElementSibling() {
+    if (!this.parentElement) return null;
+    const i = this.parentElement.children.indexOf(this);
+    return i > 0 ? this.parentElement.children[i - 1] : null;
+  }
+
+  // 守卫只用类名选择器问祖先，够用即可
+  closest(selector) {
+    const name = selector.replace(/^\./, '');
+    for (let n = this; n; n = n.parentElement) if (n.classList.contains(name)) return n;
+    return null;
+  }
+
+  contains(other) {
+    for (let n = other; n; n = n.parentElement) if (n === this) return true;
+    return false;
+  }
+
+  setAttribute(name) { this.attributes.add(name); }
+  removeAttribute(name) { this.attributes.delete(name); }
+  hasAttribute(name) { return this.attributes.has(name); }
+
   // 站点定死的高度，不随内容变 —— 这正是本文件要处理的那类框
-  get clientHeight() { return this.height; }
+  get clientHeight() { return this.hidden ? 0 : this.height; }
+  get scrollHeight() { return this.ownScrollHeight === null ? this.clientHeight : this.ownScrollHeight; }
 
   getBoundingClientRect() {
-    return { top: this.top, bottom: this.top + this.height, height: this.height, width: 100 };
+    if (this.hidden) return { top: 0, bottom: 0, height: 0, width: 0 };
+    return { top: this.top, bottom: this.top + this.height, height: this.height, width: this.width };
   }
 }
 
@@ -81,6 +122,34 @@ globalThis.document = { body: new FakeElement(), documentElement: new FakeElemen
 await import('../../content/content-fit-guard.js');
 const ctx = globalThis.window.AI_TRANSLATOR_CONTENT;
 const { body } = globalThis.document;
+
+// content-page-translation.js 那半边的替身：藏原文 = display:none，它的矩形塌成 0，
+// 后面的译文在正常流里往上补上那段高度 —— 守卫重量一次量的正是这个之后的样子。
+// 每个测试自己装，用完拆掉；默认不装是为了让「原文让不出去」那条路也测得到。
+function withSourceYielding(fn) {
+  const yielded = [];
+  ctx.hideCrowdedSource = (translationEl) => {
+    const source = translationEl.previousElementSibling;
+    if (!source || !source.classList.contains('ai-translator-translated')) return false;
+    source.hidden = true;
+    translationEl.top -= source.height;
+    translationEl.setAttribute('data-ai-translator-crowded');
+    yielded.push(source);
+    return true;
+  };
+  ctx.releaseSourceForTranslation = (translationEl) => {
+    translationEl.removeAttribute('data-ai-translator-crowded');
+    const source = translationEl.previousElementSibling;
+    if (source && source.hidden) {
+      source.hidden = false;
+      translationEl.top += source.height;
+    }
+  };
+  try { return fn(yielded); } finally {
+    delete ctx.hideCrowdedSource;
+    delete ctx.releaseSourceForTranslation;
+  }
+}
 
 /** The real shape: a graph cell whose height the layout fixed, translation spilling out. */
 function explainerCell({ overflowY = 'visible' } = {}) {
@@ -200,4 +269,200 @@ test('removing a translation releases the clip guards taken for it', () => {
   } finally {
     delete ctx.releaseTranslationClipGuards;
   }
+});
+
+// ---------------------------------------------------------------------------
+// 装不下的时候：**先让原文，让不动才撤**。装不下两种语言不等于装不下一种。
+// ---------------------------------------------------------------------------
+
+/** 一对：原文块 + 紧跟其后的译文，同住一个高度写死的框。 */
+function crowdedPair({ hostHeight = 30, sourceHeight = 20, translationHeight = 20 } = {}) {
+  const host = new FakeElement({ top: 100, height: hostHeight });
+  const source = new FakeElement({ top: 100, height: sourceHeight, classes: ['ai-translator-translated'], text: 'Temperature' });
+  const translation = new FakeElement({ top: 100 + sourceHeight, height: translationHeight });
+  host.append(source);
+  host.append(translation);
+  body.append(host);
+  return { host, source, translation };
+}
+
+test('a block that cannot hold both languages keeps the translation and yields the source', () => {
+  // 40px 的内容塞进 30px 的框：撤译文用户什么都没得到，让原文他读到的正是他要的那行
+  withSourceYielding(() => {
+    const { source, translation } = crowdedPair();
+    assert.equal(ctx.keepTranslationInFlow(translation), true);
+    assert.equal(translation.isConnected, true, 'the translation was dropped even though the source could yield');
+    assert.equal(source.hidden, true, 'the source did not yield');
+    assert.equal(translation.hasAttribute('data-ai-translator-crowded'), true,
+      'without the marker a showTranslationOnly toggle would un-hide the source and re-garble the block');
+  });
+});
+
+test('a source that yielded and still does not fit gets put back, and the translation goes', () => {
+  // 让了也没用（框连译文一个人都装不下）：两个都藏着的话这一块彻底空白，
+  // 比重叠糟得多
+  withSourceYielding(() => {
+    const { source, translation } = crowdedPair({ hostHeight: 10, sourceHeight: 20, translationHeight: 40 });
+    assert.equal(ctx.keepTranslationInFlow(translation), false);
+    assert.equal(translation.isConnected, false);
+    assert.equal(source.hidden, false, 'the source stayed hidden with no translation to show for it');
+    assert.equal(translation.hasAttribute('data-ai-translator-crowded'), false,
+      'the crowded marker outlived the translation it was set for');
+  });
+});
+
+test('the source is put back even when it was hidden by translation-only mode', () => {
+  // 「仅显示译文」开着时原文在守卫跑之前就藏好了，这时守卫的 hideCrowdedSource 可能
+  // 一开始就说不（比如原文是被 wrap 包起来的那种）。撤译文那条路照样要放原文。
+  let releasedFor = null;
+  ctx.hideCrowdedSource = () => false;
+  ctx.releaseSourceForTranslation = (el) => { releasedFor = el; };
+  try {
+    const { translation } = explainerCell();
+    assert.equal(ctx.keepTranslationInFlow(translation), false);
+    assert.equal(releasedFor, translation, 'the block was left with neither language in it');
+  } finally {
+    delete ctx.hideCrowdedSource;
+    delete ctx.releaseSourceForTranslation;
+  }
+});
+
+test('a box that is fixed-height and bottom-anchored pushes the source out, not the translation', () => {
+  // transformer-explainer 顶部的 .title：display:flex; justify-content:end，高 80px
+  // 写死。插一行译文，译文稳稳待在框底，被顶出框顶的是原文，往上撞进上一行。
+  // 只量译文自己的矩形，这一整类永远量不到。
+  withSourceYielding(() => {
+    const host = new FakeElement({ top: 100, height: 80 });
+    const source = new FakeElement({ top: 72, height: 28, classes: ['ai-translator-translated'], text: 'Multi-head Self Attention' });
+    const translation = new FakeElement({ top: 140, height: 28 });
+    host.append(source);
+    host.append(translation);
+    body.append(host);
+
+    assert.ok(translation.getBoundingClientRect().bottom <= host.getBoundingClientRect().bottom,
+      'setup: the translation itself must sit comfortably inside the box');
+    assert.equal(ctx.keepTranslationInFlow(translation), true);
+    assert.equal(source.hidden, true, 'the source was pushed out of the top and nobody noticed');
+  });
+});
+
+test('a source whose own box cannot hold its own text is treated as no box at all', () => {
+  // 顶栏的 Temperature / Sampling / Probabilities：clientHeight 0，字画在盒子外面。
+  // 盒子没有高度，挨着它摆的任何东西都落在同一个 y 上 —— 「温度perature」。
+  // 宿主本身好好的，是原文块的几何在撒谎。
+  withSourceYielding(() => {
+    const host = new FakeElement({ top: 100, height: 400 });
+    const source = new FakeElement({
+      top: 100, height: 0, scrollHeight: 22,
+      classes: ['ai-translator-translated'], text: 'Temperature',
+    });
+    const translation = new FakeElement({ top: 100, height: 22 });
+    host.append(source);
+    host.append(translation);
+    body.append(host);
+
+    assert.equal(ctx.keepTranslationInFlow(translation), true);
+    assert.equal(source.hidden, true, 'the translation was laid on top of text painted outside its own box');
+  });
+});
+
+test('a source that fits its own text is not mistaken for a lying box', () => {
+  // 上一条的反面：正常段落 scrollHeight == clientHeight，别拿它当撒谎的盒子
+  withSourceYielding(() => {
+    const host = new FakeElement({ top: 100, height: 400 });
+    const source = new FakeElement({ top: 100, height: 40, classes: ['ai-translator-translated'], text: 'A normal paragraph' });
+    const translation = new FakeElement({ top: 140, height: 40 });
+    host.append(source);
+    host.append(translation);
+    body.append(host);
+
+    assert.equal(ctx.keepTranslationInFlow(translation), true);
+    assert.equal(source.hidden, false, 'a plain paragraph had its source hidden');
+  });
+});
+
+test('a source nested around the translation is measured by the pair, not twice', () => {
+  // 水平 flex / 表格单元格 / slot：译文插在原文**里面**，原文的矩形已经含着它。
+  // 拿它自己的 scrollHeight 去问「装不装得下自己的字」会把译文也算进去，永远为真。
+  withSourceYielding(() => {
+    const host = new FakeElement({ top: 100, height: 400 });
+    const source = new FakeElement({
+      top: 100, height: 20, scrollHeight: 40,
+      classes: ['ai-translator-translated'], text: 'Cell',
+    });
+    const translation = new FakeElement({ top: 100, height: 20 });
+    source.append(translation);
+    host.append(source);
+    body.append(host);
+
+    assert.equal(ctx.keepTranslationInFlow(translation), true);
+    assert.equal(source.hidden, false,
+      'the containing source was hidden — which would take the translation inside it down too');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 横向：**这一块比页面原本给它的地方宽了**，而且它推不开邻居，只能盖上去。
+// ---------------------------------------------------------------------------
+
+/**
+ * 收缩包裹的一列：英文在 112px 里排得下，中文一行排下来把整块撑到 147px。
+ * @param {{position?: string, sourceWidthAfter?: number, translationWidth?: number}} opts
+ *   position 是外层那一列的定位方式 —— 出了流才推不开邻居。
+ */
+function shrinkToFitColumn({ position = 'absolute', sourceWidthAfter = 147,
+  translationWidth = 147 } = {}) {
+  const column = new FakeElement({ top: 0, height: 200, position });
+  const holder = new FakeElement({ top: 0, height: 60 });
+  const source = new FakeElement({
+    top: 0, height: 30, width: sourceWidthAfter,
+    classes: ['ai-translator-translated'], text: '11 more identical Transformer Blocks',
+  });
+  const translation = new FakeElement({ top: 30, height: 30, width: translationWidth });
+  holder.append(source);
+  holder.append(translation);
+  column.append(holder);
+  body.append(column);
+  return { column, holder, source, translation };
+}
+
+test('a block that outgrew its column is dropped when the column cannot push its neighbours', () => {
+  // 112 → 147px，外面那一列是 absolute：长出来的 35px 推不开隔壁，直接盖上去
+  const { translation } = shrinkToFitColumn();
+  assert.equal(ctx.keepTranslationInFlow(translation, 112), false);
+  assert.equal(translation.isConnected, false);
+});
+
+test('the same widening in normal flow is left alone — the neighbours just move over', () => {
+  // 表格单元格、按钮、inline-block 变宽都是这一类：页面重排一遍就好了，不关我们的事
+  const { translation } = shrinkToFitColumn({ position: 'static' });
+  assert.equal(ctx.keepTranslationInFlow(translation, 112), true);
+  assert.equal(translation.isConnected, true);
+});
+
+test('a translation that got wide on its own, without widening the block, is left alone', () => {
+  // Anthropic 那两条「跳到主要内容」：译文继承了原文的 absolute，刚被按回 static，
+  // 于是自己从 206px 摊成整行 1585px。可原文块一点没变宽 —— 框没变，谁也没挤到。
+  // 判据量的是原文块，不是这一对的并集，就是为了不把这一类算进来。
+  const { translation } = shrinkToFitColumn({ sourceWidthAfter: 206, translationWidth: 1585 });
+  assert.equal(ctx.keepTranslationInFlow(translation, 206), true);
+  assert.equal(translation.isConnected, true);
+});
+
+test('without a pre-insert width the horizontal rule stays out of it', () => {
+  // 悬停/划词那条路不量宽度，也就没有「原本给了多少」这个参照 —— 没有参照就不判
+  const { translation } = shrinkToFitColumn();
+  assert.equal(ctx.keepTranslationInFlow(translation), true);
+  assert.equal(translation.isConnected, true);
+});
+
+test('a block that outgrew its column is dropped outright, without asking the source to yield', () => {
+  // 前三条让原文有用，是因为框里挤的是两个人；这里把框撑宽的正是译文自己，
+  // 原文让开框还是那么宽 —— 白让一次，还得再撤一次。
+  withSourceYielding((yielded) => {
+    const { source, translation } = shrinkToFitColumn();
+    assert.equal(ctx.keepTranslationInFlow(translation, 112), false);
+    assert.deepEqual(yielded, [], 'the source was asked to yield for a widening it cannot fix');
+    assert.equal(source.hidden, false);
+  });
 });


### PR DESCRIPTION
## Background
- This PR packages the current branch changes for review.
- It groups the current branch updates into one reviewable change.

## Solution
- fix: keep the translation and yield the source when a block holds only one

## Affected Files
- `content/content-fit-guard.js`
- `content/content-page-translation.js`
- `test/unit/clip-guard.test.mjs`
- `test/unit/fit-guard.test.mjs`