### PR TITLE
fix(test): stop mock-server teardown from hanging for 60s

### DIFF
--- a/test/e2e/clipped-container-translation.spec.js
+++ b/test/e2e/clipped-container-translation.spec.js
@@ -42,7 +42,7 @@ const check = (page, selector) =>
 
 test.describe('translations clipped by a collapsed ancestor', () => {
   test('hover translation is revealed, and the clip is restored afterwards', async ({ page }) => {
-    const { server, endpoint } = await startMockOpenAIServer();
+    const { close, endpoint } = await startMockOpenAIServer();
 
     try {
       await setExtensionSettings(page, {
@@ -88,12 +88,12 @@ test.describe('translations clipped by a collapsed ancestor', () => {
         })()`), { timeout: 5000 })
         .toEqual(before);
     } finally {
-      server.close();
+      await close();
     }
   });
 
   test('whole-page translation is revealed too', async ({ page }) => {
-    const { server, endpoint } = await startMockOpenAIServer();
+    const { close, endpoint } = await startMockOpenAIServer();
 
     try {
       await setExtensionSettings(page, {
@@ -122,7 +122,7 @@ test.describe('translations clipped by a collapsed ancestor', () => {
         })
         .toMatchObject({ inside: true });
     } finally {
-      server.close();
+      await close();
     }
   });
 });

--- a/test/e2e/comic-account.spec.js
+++ b/test/e2e/comic-account.spec.js
@@ -7,9 +7,9 @@
  * and the rendering of the numbers the user actually acts on. The popup is
  * here too, to prove it stays out of this entirely.
  */
-const http = require('node:http');
 const { test, expect } = require('./fixtures');
 const { getServiceWorker } = require('./helpers');
+const { startMockServer } = require('./mock-server');
 
 const RESETS_AT = '2099-02-01T00:00:00.000Z';
 const quota = (limit, remaining) => ({
@@ -36,12 +36,12 @@ const ACCOUNT = {
  * @param {number} connectDelayMs the same, for the sign-in bounce, so a second
  *   gate can arrive while the first authentication is still running.
  */
-function startMockService({ connect = 'token', meDelayMs = 0, connectDelayMs = 0 } = {}) {
+async function startMockService({ connect = 'token', meDelayMs = 0, connectDelayMs = 0 } = {}) {
   // `account` is mutable so a test can spend pages mid-run, the way a
   // translation job does, and see whether the page ever notices.
   const state = { meRequests: 0, connectRequests: 0, account: ACCOUNT };
 
-  const server = http.createServer((req, res) => {
+  const { origin, close } = await startMockServer((req, res) => {
     const url = new URL(req.url, `http://${req.headers.host}`);
     const send = (status, body) => {
       res.writeHead(status, { 'content-type': 'application/json', 'cache-control': 'no-store' });
@@ -78,15 +78,7 @@ function startMockService({ connect = 'token', meDelayMs = 0, connectDelayMs = 0
     send(404, { error: 'not_found' });
   });
 
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
-      resolve({
-        base: `http://localhost:${server.address().port}`,
-        state,
-        close: () => new Promise(done => server.close(done)),
-      });
-    });
-  });
+  return { base: origin, state, close };
 }
 
 /**

--- a/test/e2e/comic-translation.spec.js
+++ b/test/e2e/comic-translation.spec.js
@@ -9,10 +9,10 @@
  * click, which Playwright cannot drive — the message it sends is dispatched
  * directly instead.
  */
-const http = require('node:http');
 const zlib = require('node:zlib');
 const { test, expect } = require('./fixtures');
 const { getServiceWorker } = require('./helpers');
+const { startMockServer } = require('./mock-server');
 
 /**
  * CRC-32 of a PNG chunk.
@@ -257,7 +257,7 @@ const DATA_READER_HTML = `<!doctype html>
  * server-side, so a job held for two polls is already done by the time the new
  * document asks.
  */
-function startMockService(
+async function startMockService(
   behaviour = 'succeed',
   { hotlinkGuard = false, guardStatus = 403, resultFailures = 0, succeedAfterMs = 0 } = {},
 ) {
@@ -265,7 +265,7 @@ function startMockService(
     polls: 0, createBodies: [], sourceHits: 0, sourceDenied: 0, resultHits: 0, firstPollAt: 0,
   };
 
-  const server = http.createServer((req, res) => {
+  const { origin, close } = await startMockServer((req, res, base) => {
     const url = new URL(req.url, `http://${req.headers.host}`);
     const send = (status, body, type = 'application/json') => {
       res.writeHead(status, { 'content-type': type, 'cache-control': 'no-store' });
@@ -342,7 +342,7 @@ function startMockService(
         progress: 1,
         // A fresh signature per poll, as the real presign does. It also keeps
         // the two downloads in the expiry test from being one cached response.
-        resultUrl: `http://localhost:${server.address().port}/result.png?sig=${state.polls}`,
+        resultUrl: `${base}/result.png?sig=${state.polls}`,
         width: 800,
         height: 1200,
         pointsCharged: 10,
@@ -352,24 +352,7 @@ function startMockService(
     send(404, { error: 'not_found' });
   });
 
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
-      const port = server.address().port;
-      resolve({
-        port,
-        base: `http://localhost:${port}`,
-        state,
-        // Drop the keep-alive sockets Chrome is holding. Without this, close()
-        // waits for the browser to time them out on its own — tens of seconds
-        // of dead time inside each test's budget, which is what turned a slow
-        // test into an intermittently failing one.
-        close: () => new Promise((done) => {
-          server.close(done);
-          server.closeAllConnections?.();
-        }),
-      });
-    });
-  });
+  return { base: origin, state, close };
 }
 
 /** Point the extension at the mock and give it a token, as a real sign-in would. */

--- a/test/e2e/image-ocr.spec.js
+++ b/test/e2e/image-ocr.spec.js
@@ -14,11 +14,11 @@
  * cannot drive — the OCR_TRANSLATE_IMAGE message it would send is dispatched
  * directly instead, same as the comic spec.
  */
-const http = require('node:http');
 const zlib = require('node:zlib');
 const { test, expect } = require('./fixtures');
 const { setExtensionSettings, sendMessageToActiveTab } = require('./helpers');
 const { startMockOpenAIServer } = require('./mock-openai-server');
+const { startMockServer } = require('./mock-server');
 
 // CRC-32 for PNG chunks; hand-rolled for the same runtime reason as the comic
 // spec (zlib.crc32 needs Node 20.15/22.2).
@@ -89,28 +89,23 @@ const PAGE_HTML = `<!doctype html>
 </body></html>`;
 
 function startPageServer() {
-  return new Promise((resolve) => {
-    const server = http.createServer((req, res) => {
-      if (req.url === '/') {
-        res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-        res.end(PAGE_HTML);
-      } else if (req.url === '/sign.png') {
-        res.writeHead(200, { 'Content-Type': 'image/png' });
-        res.end(SIGN_PNG);
-      } else if (req.url === '/wide.png') {
-        res.writeHead(200, { 'Content-Type': 'image/png' });
-        res.end(WIDE_PNG);
-      } else if (req.url === '/big.png') {
-        res.writeHead(200, { 'Content-Type': 'image/png' });
-        res.end(BIG_PNG);
-      } else {
-        res.writeHead(404);
-        res.end();
-      }
-    });
-    server.listen(0, '127.0.0.1', () => {
-      resolve({ server, origin: `http://127.0.0.1:${server.address().port}` });
-    });
+  return startMockServer((req, res) => {
+    if (req.url === '/') {
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end(PAGE_HTML);
+    } else if (req.url === '/sign.png') {
+      res.writeHead(200, { 'Content-Type': 'image/png' });
+      res.end(SIGN_PNG);
+    } else if (req.url === '/wide.png') {
+      res.writeHead(200, { 'Content-Type': 'image/png' });
+      res.end(WIDE_PNG);
+    } else if (req.url === '/big.png') {
+      res.writeHead(200, { 'Content-Type': 'image/png' });
+      res.end(BIG_PNG);
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
   });
 }
 
@@ -161,9 +156,9 @@ test.describe('image OCR', () => {
     await setExtensionSettings(page, baseSettings());
   });
 
-  test.afterEach(() => {
-    mock?.server.close();
-    pageServer?.server.close();
+  test.afterEach(async () => {
+    await mock?.close();
+    await pageServer?.close();
   });
 
   test('the local engine reads the image on-device, then the text is translated', async ({ page }) => {

--- a/test/e2e/input-translation.spec.js
+++ b/test/e2e/input-translation.spec.js
@@ -1,58 +1,50 @@
 const { test, expect } = require('./fixtures');
 const { setExtensionSettings, openFloatBallMenu } = require('./helpers');
-const http = require('http');
+const { startMockServer } = require('./mock-server');
 
-function startInputDictionaryMockServer() {
-  return new Promise((resolve) => {
-    const server = http.createServer((req, res) => {
-      if (req.method !== 'POST') {
-        res.writeHead(404);
-        res.end();
-        return;
+async function startInputDictionaryMockServer() {
+  const { origin, close } = await startMockServer((req, res) => {
+    if (req.method !== 'POST') {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+
+    req.on('end', () => {
+      let systemPrompt = '';
+      let text = '';
+
+      try {
+        const data = JSON.parse(body);
+        systemPrompt = data?.messages?.[0]?.content || '';
+        text = data?.messages?.[1]?.content || '';
+      } catch (error) {
+        systemPrompt = '';
+        text = '';
       }
 
-      let body = '';
-      req.on('data', (chunk) => {
-        body += chunk;
-      });
+      const isDictionaryMode = /"translation"\s+and\s+"phonetic"/i.test(systemPrompt);
+      const content = isDictionaryMode
+        ? JSON.stringify({ translation: `[DICT] ${text}`, phonetic: '/ɒn ðə flaɪ/' })
+        : `[TEXT] ${text}`;
 
-      req.on('end', () => {
-        let systemPrompt = '';
-        let text = '';
-
-        try {
-          const data = JSON.parse(body);
-          systemPrompt = data?.messages?.[0]?.content || '';
-          text = data?.messages?.[1]?.content || '';
-        } catch (error) {
-          systemPrompt = '';
-          text = '';
-        }
-
-        const isDictionaryMode = /"translation"\s+and\s+"phonetic"/i.test(systemPrompt);
-        const content = isDictionaryMode
-          ? JSON.stringify({ translation: `[DICT] ${text}`, phonetic: '/ɒn ðə flaɪ/' })
-          : `[TEXT] ${text}`;
-
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          choices: [{ message: { content } }]
-        }));
-      });
-    });
-
-    server.listen(0, '127.0.0.1', () => {
-      const { port } = server.address();
-      resolve({
-        server,
-        endpoint: `http://127.0.0.1:${port}/v1/chat/completions`
-      });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        choices: [{ message: { content } }]
+      }));
     });
   });
+
+  return { endpoint: `${origin}/v1/chat/completions`, close };
 }
 
 test('input translation shows phonetic for words and read-aloud for anything typed', async ({ page }) => {
-  const { server, endpoint } = await startInputDictionaryMockServer();
+  const { close, endpoint } = await startInputDictionaryMockServer();
 
   try {
     await setExtensionSettings(page, {
@@ -102,7 +94,7 @@ test('input translation shows phonetic for words and read-aloud for anything typ
     await page.fill('#ai-translator-input-text', '');
     await expect(page.locator('#ai-translator-input-speak')).toBeHidden();
   } finally {
-    server.close();
+    await close();
   }
 });
 
@@ -183,60 +175,52 @@ const HOSTILE_INHERITED_CSS = `
  * page to run it on. The page serves HOSTILE_PAGE_CSS — see above for why that
  * is the point of the fixture rather than incidental to it.
  */
-function startTargetLangFixture() {
+async function startTargetLangFixture() {
   const LANGUAGE_NAMES = {
     'zh-CN': '简体中文',
     'ja': '日本語',
     'fr': 'Français',
   };
 
-  return new Promise((resolve) => {
-    const api = http.createServer((req, res) => {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        let systemPrompt = '';
-        let text = '';
-        try {
-          const data = JSON.parse(body);
-          systemPrompt = data?.messages?.[0]?.content || '';
-          text = data?.messages?.[1]?.content || '';
-        } catch (error) {
-          systemPrompt = '';
-        }
-        // The prompt names the target in that language's own words — see
-        // languageNames in background/background.js.
-        const asked = Object.entries(LANGUAGE_NAMES)
-          .find(([, name]) => systemPrompt.includes(name));
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({
-          choices: [{ message: { content: `[${asked ? asked[0] : 'unknown'}] ${text}` } }]
-        }));
-      });
-    });
-
-    const site = http.createServer((req, res) => {
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.end(`<!doctype html><html><head><style>${HOSTILE_PAGE_CSS}</style></head>`
-        + '<body class="host-kit"><h1>Hostile stylesheet page</h1><p>Body text.</p>'
-        // A div of the page's own, so a test can check the page rules are
-        // actually live before asserting they did not reach us.
-        + '<div id="host-canary">Host div</div>'
-        + '<button id="host-button" type="button">Host button</button></body></html>');
-    });
-
-    api.listen(0, '127.0.0.1', () => {
-      site.listen(0, '127.0.0.1', () => {
-        resolve({
-          api,
-          site,
-          endpoint: `http://127.0.0.1:${api.address().port}/v1/chat/completions`,
-          url: `http://127.0.0.1:${site.address().port}/`,
-          close() { api.close(); site.close(); },
-        });
-      });
+  const api = await startMockServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      let systemPrompt = '';
+      let text = '';
+      try {
+        const data = JSON.parse(body);
+        systemPrompt = data?.messages?.[0]?.content || '';
+        text = data?.messages?.[1]?.content || '';
+      } catch (error) {
+        systemPrompt = '';
+      }
+      // The prompt names the target in that language's own words — see
+      // languageNames in background/background.js.
+      const asked = Object.entries(LANGUAGE_NAMES)
+        .find(([, name]) => systemPrompt.includes(name));
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({
+        choices: [{ message: { content: `[${asked ? asked[0] : 'unknown'}] ${text}` } }]
+      }));
     });
   });
+
+  const site = await startMockServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(`<!doctype html><html><head><style>${HOSTILE_PAGE_CSS}</style></head>`
+      + '<body class="host-kit"><h1>Hostile stylesheet page</h1><p>Body text.</p>'
+      // A div of the page's own, so a test can check the page rules are
+      // actually live before asserting they did not reach us.
+      + '<div id="host-canary">Host div</div>'
+      + '<button id="host-button" type="button">Host button</button></body></html>');
+  });
+
+  return {
+    endpoint: `${api.origin}/v1/chat/completions`,
+    url: `${site.origin}/`,
+    close: () => Promise.all([api.close(), site.close()]),
+  };
 }
 
 async function openInputDialog(page) {
@@ -285,7 +269,7 @@ test('the input dialog translates into the language picked in it, not the one in
     await page.click('#ai-translator-do-translate');
     await expect(page.locator('#ai-translator-result-text')).toContainText('[ja]');
   } finally {
-    fixture.close();
+    await fixture.close();
   }
 });
 
@@ -319,7 +303,7 @@ test('setting a target language in settings overrides what the input dialog reme
     await page.click('#ai-translator-do-translate');
     await expect(page.locator('#ai-translator-result-text')).toContainText('[fr]');
   } finally {
-    fixture.close();
+    await fixture.close();
   }
 });
 
@@ -445,7 +429,7 @@ test('a theme\'s button style cannot reach our controls', async ({ page }) => {
     expect(trigger.padding).toBe('7px 12px 7px 14px');
     expect(trigger['font-weight']).toBe('500');
   } finally {
-    fixture.close();
+    await fixture.close();
   }
 });
 
@@ -556,7 +540,7 @@ test('a hostile host stylesheet cannot reach into the dialog', async ({ page }) 
     });
     expect(menuIsOnTop).toBe(true);
   } finally {
-    fixture.close();
+    await fixture.close();
   }
 });
 
@@ -607,7 +591,7 @@ test('the containment reset does not outrank our own fade-in', async ({ page }) 
       .poll(async () => (await computed(page, '.ai-translator-input-modal', ['opacity'])).opacity)
       .toBe('1');
   } finally {
-    fixture.close();
+    await fixture.close();
   }
 });
 

--- a/test/e2e/mock-openai-server.js
+++ b/test/e2e/mock-openai-server.js
@@ -12,7 +12,7 @@
  * numbered format — but every segment after the first comes back byte-identical to its
  * source, and shouldSkipTranslation() then silently drops it as "already translated".
  */
-const http = require('http');
+const { startMockServer } = require('./mock-server');
 
 const PROMPT_DELIMITER_RE = /segments are separated by "([^"]+)"/;
 
@@ -32,7 +32,7 @@ function pngDataUrlSize(dataUrl) {
   return { width: bytes.readUInt32BE(16), height: bytes.readUInt32BE(20) };
 }
 
-function startMockOpenAIServer() {
+async function startMockOpenAIServer() {
   // One entry per request that took the fast-batch path, so tests can assert the mock
   // really spoke the delimiter protocol rather than falling through to the single-text path.
   const fastBatchRequests = [];
@@ -46,88 +46,83 @@ function startMockOpenAIServer() {
   // OpenAI shape, not just that a popup rendered something.
   const visionRequests = [];
 
-  return new Promise((resolve) => {
-    const server = http.createServer((req, res) => {
-      if (req.method !== 'POST') {
-        res.writeHead(404);
-        res.end();
+  const { origin, close } = await startMockServer((req, res) => {
+    if (req.method !== 'POST') {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      let content = '';
+      let systemPrompt = '';
+      try {
+        const data = JSON.parse(body);
+        const messages = data?.messages || [];
+        content = messages[messages.length - 1]?.content || '';
+        systemPrompt = messages.find((m) => m?.role === 'system')?.content || '';
+      } catch {
+        content = '';
+      }
+
+      // A vision request: [{type:'text'},{type:'image_url'}]. Answer with the JSON
+      // contract from shared/ocr.js instead of the echo protocol below.
+      if (Array.isArray(content)) {
+        const imagePart = content.find((part) => part?.type === 'image_url');
+        visionRequests.push({
+          partTypes: content.map((part) => part?.type),
+          // Enough of the data URL to assert the media type without dumping megabytes
+          // of base64 into a test failure message.
+          imageUrlPrefix: String(imagePart?.image_url?.url || '').slice(0, 40),
+          // What the worker actually sent, for specs that assert on the crop.
+          imageSize: pngDataUrlSize(imagePart?.image_url?.url),
+          systemPrompt
+        });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          choices: [{
+            message: {
+              // Recognition only: the translation is a second, ordinary
+              // request, which the echo protocol below answers.
+              content: JSON.stringify({ text: 'HELLO WORLD', language: 'en' })
+            }
+          }]
+        }));
         return;
       }
 
-      let body = '';
-      req.on('data', (chunk) => {
-        body += chunk;
+      if (content) sentTexts.push(content);
+
+      const delimiter = systemPrompt.match(PROMPT_DELIMITER_RE)?.[1];
+      if (delimiter) {
+        const segments = content.split(delimiter);
+        fastBatchRequests.push({ delimiter, segmentCount: segments.length });
+        content = segments
+          .map((segment) => (segment ? `[T] ${segment}` : segment))
+          .join(delimiter);
+      } else if (content) {
+        content = `[T] ${content}`;
+      }
+
+      const response = JSON.stringify({
+        choices: [{ message: { content } }]
       });
-      req.on('end', () => {
-        let content = '';
-        let systemPrompt = '';
-        try {
-          const data = JSON.parse(body);
-          const messages = data?.messages || [];
-          content = messages[messages.length - 1]?.content || '';
-          systemPrompt = messages.find((m) => m?.role === 'system')?.content || '';
-        } catch {
-          content = '';
-        }
-
-        // A vision request: [{type:'text'},{type:'image_url'}]. Answer with the JSON
-        // contract from shared/ocr.js instead of the echo protocol below.
-        if (Array.isArray(content)) {
-          const imagePart = content.find((part) => part?.type === 'image_url');
-          visionRequests.push({
-            partTypes: content.map((part) => part?.type),
-            // Enough of the data URL to assert the media type without dumping megabytes
-            // of base64 into a test failure message.
-            imageUrlPrefix: String(imagePart?.image_url?.url || '').slice(0, 40),
-            // What the worker actually sent, for specs that assert on the crop.
-            imageSize: pngDataUrlSize(imagePart?.image_url?.url),
-            systemPrompt
-          });
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({
-            choices: [{
-              message: {
-                // Recognition only: the translation is a second, ordinary
-                // request, which the echo protocol below answers.
-                content: JSON.stringify({ text: 'HELLO WORLD', language: 'en' })
-              }
-            }]
-          }));
-          return;
-        }
-
-        if (content) sentTexts.push(content);
-
-        const delimiter = systemPrompt.match(PROMPT_DELIMITER_RE)?.[1];
-        if (delimiter) {
-          const segments = content.split(delimiter);
-          fastBatchRequests.push({ delimiter, segmentCount: segments.length });
-          content = segments
-            .map((segment) => (segment ? `[T] ${segment}` : segment))
-            .join(delimiter);
-        } else if (content) {
-          content = `[T] ${content}`;
-        }
-
-        const response = JSON.stringify({
-          choices: [{ message: { content } }]
-        });
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(response);
-      });
-    });
-
-    server.listen(0, '127.0.0.1', () => {
-      const { port } = server.address();
-      resolve({
-        server,
-        fastBatchRequests,
-        sentTexts,
-        visionRequests,
-        endpoint: `http://127.0.0.1:${port}/v1/chat/completions`
-      });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(response);
     });
   });
+
+  return {
+    fastBatchRequests,
+    sentTexts,
+    visionRequests,
+    endpoint: `${origin}/v1/chat/completions`,
+    close
+  };
 }
 
 module.exports = { startMockOpenAIServer };

--- a/test/e2e/mock-server.js
+++ b/test/e2e/mock-server.js
@@ -1,0 +1,59 @@
+/**
+ * The one HTTP server every E2E mock is built on.
+ *
+ * It exists for its close(). `server.close(cb)` on its own does not reliably
+ * come back: Node stops listening and reaps *idle* keep-alive sockets at once,
+ * but a socket that has connected and sent no request bytes counts as a request
+ * still arriving, and it is held until `server.headersTimeout` — 60 seconds by
+ * default. Chrome opens exactly such a socket: alongside a navigation it
+ * speculatively preconnects a second connection to the same origin, and often
+ * sends nothing on it. Whether the browser's pool has dropped that socket by
+ * the time a test tears down is a race, so `await service.close()` returned in
+ * under a millisecond almost always and blocked for a full minute now and
+ * then — inside the test's own 60s budget, with every assertion in the body
+ * already passed.
+ *
+ * That is the flake this module was extracted for: comic-account.spec.js failing
+ * as a bare "Test timeout of 60000ms exceeded" with no Playwright call log, only
+ * under a loaded full-suite run, never when the file ran alone.
+ * closeAllConnections() destroys those sockets instead of waiting them out.
+ * Three specs had already grown a private copy of that call and the fourth had
+ * not, which is why the server now has one home.
+ *
+ * Guarded by test/unit/e2e-mock-server.test.mjs: it holds a silent socket open
+ * and requires close() to resolve anyway, and it fails any spec that stands up
+ * an http server of its own.
+ *
+ * The origin is 127.0.0.1 rather than localhost, matching the bind address —
+ * `localhost` can resolve to ::1 first, and nothing is listening there.
+ *
+ * @param {(req: import('node:http').IncomingMessage,
+ *          res: import('node:http').ServerResponse,
+ *          origin: string) => void} handler
+ *   The request listener. Its third argument is this server's own origin, for
+ *   mocks that hand out URLs pointing back at themselves (a presigned result
+ *   URL, an upload sink) and so cannot be written before the port is known.
+ * @returns {Promise<{port: number, origin: string, close: () => Promise<void>}>}
+ */
+const http = require('node:http');
+
+function startMockServer(handler) {
+  return new Promise((resolve) => {
+    let origin = '';
+    const server = http.createServer((req, res) => handler(req, res, origin));
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      origin = `http://127.0.0.1:${port}`;
+      resolve({
+        port,
+        origin,
+        close: () => new Promise((done) => {
+          server.close(done);
+          server.closeAllConnections();
+        }),
+      });
+    });
+  });
+}
+
+module.exports = { startMockServer };

--- a/test/e2e/page-translation-highlight-class.spec.js
+++ b/test/e2e/page-translation-highlight-class.spec.js
@@ -28,7 +28,7 @@ const { startMockOpenAIServer } = require('./mock-openai-server');
 // text: code-looking text would also be dropped by the looksLikeCode() heuristics,
 // and the test would then pass even if the class rule were deleted outright.
 test('page translation: "highlights"/"language-" lookalikes translate, real code containers stay skipped', async ({ page }) => {
-  const { server, endpoint, fastBatchRequests } = await startMockOpenAIServer();
+  const { close, endpoint, fastBatchRequests } = await startMockOpenAIServer();
 
   try {
     await setExtensionSettings(page, {
@@ -114,6 +114,6 @@ test('page translation: "highlights"/"language-" lookalikes translate, real code
     await expect(page.locator('#github-container .ai-translator-inline-block')).toHaveCount(0);
     await expect(page.locator('#prism-container .ai-translator-inline-block')).toHaveCount(0);
   } finally {
-    server.close();
+    await close();
   }
 });

--- a/test/e2e/page-translation-inline-skip.spec.js
+++ b/test/e2e/page-translation-inline-skip.spec.js
@@ -3,7 +3,7 @@ const { setExtensionSettings, triggerPageTranslation } = require('./helpers');
 const { startMockOpenAIServer } = require('./mock-openai-server');
 
 test('page translation skips blocks with inline translation', async ({ page }) => {
-  const { server, endpoint, fastBatchRequests } = await startMockOpenAIServer();
+  const { close, endpoint, fastBatchRequests } = await startMockOpenAIServer();
 
   try {
     await setExtensionSettings(page, {
@@ -56,6 +56,6 @@ test('page translation skips blocks with inline translation', async ({ page }) =
     await expect(paragraphOne).not.toHaveClass(/ai-translator-translated/);
     await expect(page.locator('#inline-translation-test .ai-translator-inline-block')).toHaveCount(2);
   } finally {
-    server.close();
+    await close();
   }
 });

--- a/test/e2e/page-translation-paper-listing.spec.js
+++ b/test/e2e/page-translation-paper-listing.spec.js
@@ -37,7 +37,7 @@ const ARXIV_LISTING = `
 `;
 
 test('page translation: arXiv/LaTeXML code listings never reach the API, paper prose still does', async ({ page }) => {
-  const { server, endpoint, fastBatchRequests, sentTexts } = await startMockOpenAIServer();
+  const { close, endpoint, fastBatchRequests, sentTexts } = await startMockOpenAIServer();
 
   try {
     await setExtensionSettings(page, {
@@ -105,6 +105,6 @@ test('page translation: arXiv/LaTeXML code listings never reach the API, paper p
     await expect(page.locator('#S3\\.SS1\\.p4\\.1 .ai-translator-inline-block')).toHaveCount(0);
     await expect(page.locator('#S3\\.SS1\\.p4\\.1 .ai-translator-translated')).toHaveCount(0);
   } finally {
-    server.close();
+    await close();
   }
 });

--- a/test/e2e/pdf-history-link.spec.js
+++ b/test/e2e/pdf-history-link.spec.js
@@ -11,9 +11,9 @@
  * mock's), and that it reaches the DOM on the first render rather than one
  * poll later.
  */
-const http = require('node:http');
 const { test, expect } = require('./fixtures');
 const { getServiceWorker } = require('./helpers');
+const { startMockServer } = require('./mock-server');
 
 const ACCOUNT = {
   email: 'reader@example.com',
@@ -39,8 +39,8 @@ const JOBS = [
   },
 ];
 
-function startMockService() {
-  const server = http.createServer((req, res) => {
+async function startMockService() {
+  const { origin, close } = await startMockServer((req, res) => {
     const url = new URL(req.url, `http://${req.headers.host}`);
     const send = (status, body) => {
       res.writeHead(status, { 'content-type': 'application/json', 'cache-control': 'no-store' });
@@ -54,14 +54,7 @@ function startMockService() {
     send(404, { error: 'not_found' });
   });
 
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
-      resolve({
-        base: `http://localhost:${server.address().port}`,
-        close: () => new Promise(done => { server.close(done); server.closeAllConnections?.(); }),
-      });
-    });
-  });
+  return { base: origin, close };
 }
 
 async function connectExtension(context, base) {
@@ -94,7 +87,7 @@ test.describe('PDF history → web library', () => {
       await expect(history.locator('.pdf-task-view').first())
         .toHaveAttribute('href', `${service.base}/settings/pdf?job=pdf_done`);
       // Built from the configured origin, not from a hardcoded production one.
-      expect(service.base.startsWith('http://localhost:')).toBe(true);
+      expect(service.base.startsWith('http://127.0.0.1:')).toBe(true);
 
       // A failure gets one too: the library still has the original, which is
       // how "what was this file?" gets answered.

--- a/test/e2e/pdf-translation.spec.js
+++ b/test/e2e/pdf-translation.spec.js
@@ -13,9 +13,9 @@
  * back at this server, a PUT sink that checks it was truly handed a PDF, a
  * 202 job creation, and a poll that goes running → succeeded.
  */
-const http = require('node:http');
 const { test, expect } = require('./fixtures');
 const { getServiceWorker } = require('./helpers');
+const { startMockServer } = require('./mock-server');
 
 /**
  * A minimal PDF as a static byte template.
@@ -49,7 +49,7 @@ trailer
  * 402 the UI has a distinct answer for. The 401 case needs no behaviour at
  * all: without a token the client must refuse before any request is made.
  */
-function startMockService(behaviour = 'succeed') {
+async function startMockService(behaviour = 'succeed') {
   const state = {
     uploadTickets: [],
     uploadPuts: [],
@@ -57,7 +57,7 @@ function startMockService(behaviour = 'succeed') {
     polls: 0,
   };
 
-  const server = http.createServer((req, res) => {
+  const { origin, close } = await startMockServer((req, res, base) => {
     const url = new URL(req.url, `http://${req.headers.host}`);
     const send = (status, body, type = 'application/json') => {
       res.writeHead(status, { 'content-type': type, 'cache-control': 'no-store' });
@@ -71,7 +71,6 @@ function startMockService(behaviour = 'succeed') {
     };
 
     const authorized = (req.headers.authorization || '').startsWith('Bearer ');
-    const base = () => `http://localhost:${server.address().port}`;
 
     if (url.pathname === '/api/pdf/uploads' && req.method === 'POST') {
       return readBody((raw) => {
@@ -83,7 +82,7 @@ function startMockService(behaviour = 'succeed') {
         const sourceKey = `pdf/u1/${body.operationId}/source.pdf`;
         return send(200, {
           sourceKey,
-          uploadUrl: `${base()}/upload-sink?key=${encodeURIComponent(sourceKey)}`,
+          uploadUrl: `${base}/upload-sink?key=${encodeURIComponent(sourceKey)}`,
           maxBytes: 30 * 1024 * 1024,
         });
       });
@@ -160,8 +159,8 @@ function startMockService(behaviour = 'succeed') {
         pointsCharged: 3,
         // A fresh signature per poll, as the real presign does.
         results: {
-          dualUrl: `${base()}/result-dual.pdf?sig=${state.polls}`,
-          monoUrl: `${base()}/result-mono.pdf?sig=${state.polls}`,
+          dualUrl: `${base}/result-dual.pdf?sig=${state.polls}`,
+          monoUrl: `${base}/result-mono.pdf?sig=${state.polls}`,
         },
       });
     }
@@ -173,18 +172,7 @@ function startMockService(behaviour = 'succeed') {
     send(404, { error: 'not_found' });
   });
 
-  return new Promise((resolve) => {
-    server.listen(0, '127.0.0.1', () => {
-      resolve({
-        base: `http://localhost:${server.address().port}`,
-        state,
-        close: () => new Promise((done) => {
-          server.close(done);
-          server.closeAllConnections?.();
-        }),
-      });
-    });
-  });
+  return { base: origin, state, close };
 }
 
 /**

--- a/test/e2e/selection-popup-pronunciation.spec.js
+++ b/test/e2e/selection-popup-pronunciation.spec.js
@@ -6,27 +6,22 @@
 // otherwise only show up in a user's hands.
 const { test, expect } = require('./fixtures');
 const { setExtensionSettings, openFloatBallMenu } = require('./helpers');
-const http = require('http');
+const { startMockServer } = require('./mock-server');
 
-function startMockServer(reply) {
-  return new Promise((resolve) => {
-    const server = http.createServer((req, res) => {
-      let body = '';
-      req.on('data', (chunk) => { body += chunk; });
-      req.on('end', () => {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ choices: [{ message: { content: reply } }] }));
-      });
-    });
-    server.listen(0, '127.0.0.1', () => {
-      const { port } = server.address();
-      resolve({ server, endpoint: `http://127.0.0.1:${port}/v1/chat/completions` });
+async function startReplyMockServer(reply) {
+  const { origin, close } = await startMockServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk) => { body += chunk; });
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ choices: [{ message: { content: reply } }] }));
     });
   });
+  return { endpoint: `${origin}/v1/chat/completions`, close };
 }
 
 test('the selection popup can read out both the original and the translation', async ({ page }) => {
-  const { server, endpoint } = await startMockServer('示例域名');
+  const { close, endpoint } = await startReplyMockServer('示例域名');
 
   try {
     await setExtensionSettings(page, {
@@ -75,6 +70,6 @@ test('the selection popup can read out both the original and the translation', a
     ]);
     expect(labels[0]).not.toEqual(labels[1]);
   } finally {
-    server.close();
+    await close();
   }
 });

--- a/test/unit/e2e-mock-server.test.mjs
+++ b/test/unit/e2e-mock-server.test.mjs
@@ -1,0 +1,115 @@
+// Guards for the E2E mock server — test/e2e/mock-server.js.
+//
+// The bug these exist for: `new Promise(done => server.close(done))`. Node stops
+// listening at once and reaps idle keep-alive sockets, but a socket that has
+// connected and sent no request bytes counts as a request still arriving, and it
+// is held until `server.headersTimeout` — 60 seconds by default. Chrome opens
+// exactly such a socket: it speculatively preconnects a second connection to the
+// origin it is navigating to, and often sends nothing on it.
+//
+// So `await service.close()` in a spec's finally block returned instantly almost
+// always, and once in every dozen full-suite runs sat there for the whole
+// minute. The test had already passed every assertion in its body; Playwright
+// killed it at the test timeout and reported a bare "Test timeout of 60000ms
+// exceeded" with no call log, because the hang was not inside a Playwright call.
+// It reproduced only under a loaded full-suite run and never when the file ran
+// alone, which is what made it read as a browser race rather than teardown.
+//
+// The first test below is that failure, in a form that takes milliseconds: hold
+// one silent socket open and require close() to resolve anyway. It fails — by
+// timing out — against the old teardown.
+//
+// Run with: npm run test:unit
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const repoFile = (rel) => readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8');
+const require = createRequire(import.meta.url);
+
+const { startMockServer } = require('../e2e/mock-server.js');
+
+/** Resolves to 'timeout' if the promise has not settled by `ms`. */
+const within = (promise, ms) => Promise.race([
+  promise.then(() => 'settled'),
+  new Promise(resolve => setTimeout(() => resolve('timeout'), ms).unref?.()),
+]);
+
+test('close() returns even while a connection that sent no request is open', async () => {
+  const service = await startMockServer((req, res) => { res.writeHead(200); res.end('ok'); });
+
+  // A real request first, so the server has a live keep-alive socket too.
+  assert.equal(await (await fetch(`${service.origin}/`)).text(), 'ok');
+
+  // And the one Chrome adds by preconnecting: connected, silent, never used.
+  const silent = net.connect(service.port, '127.0.0.1');
+  await new Promise((resolve, reject) => { silent.on('connect', resolve); silent.on('error', reject); });
+
+  const closed = service.close();
+  try {
+    assert.equal(await within(closed, 2000), 'settled',
+      'close() is waiting out headersTimeout on the silent socket — the 60s teardown hang is back');
+  } finally {
+    // Unblocks a close() that is failing this test, so it fails by reporting
+    // rather than by holding the event loop open for the next 58 seconds.
+    silent.destroy();
+    await closed;
+  }
+});
+
+test('close() resolves only once the port is free again', async () => {
+  // The point of awaiting it at all: a close() that resolved early would leave
+  // the next test racing a listener that is still up.
+  const service = await startMockServer((req, res) => { res.writeHead(200); res.end('ok'); });
+  await (await fetch(`${service.origin}/`)).text();
+  await service.close();
+
+  await new Promise((resolve, reject) => {
+    const probe = net.createServer();
+    probe.once('error', reject);
+    probe.listen(service.port, '127.0.0.1', () => probe.close(resolve));
+  });
+});
+
+test('the handler is handed its own origin', async () => {
+  // comic-translation and pdf-translation mocks hand out URLs pointing back at
+  // themselves (a presigned result, an upload sink), which cannot be written
+  // before the port is known.
+  const service = await startMockServer((req, res, origin) => {
+    res.writeHead(200);
+    res.end(origin);
+  });
+  assert.equal(await (await fetch(`${service.origin}/`)).text(), service.origin);
+  assert.match(service.origin, /^http:\/\/127\.0\.0\.1:\d+$/,
+    'the origin has to match the bind address — localhost can resolve to ::1, where nothing is listening');
+  await service.close();
+});
+
+const e2eFiles = () => readdirSync(fileURLToPath(new URL('../e2e/', import.meta.url)))
+  .filter(name => name.endsWith('.js') && name !== 'mock-server.js');
+
+// Every one of these mocks was written the same way, and three of them had grown
+// a private closeAllConnections() while the fourth — the one that was flaking —
+// had not. A spec that stands up its own server is a spec that has to remember
+// the teardown for itself, so the way to stop the fix from being half-applied
+// again is to leave nowhere else to create one.
+test('no E2E file stands up an HTTP server of its own', () => {
+  const offenders = e2eFiles()
+    .filter(name => /createServer\(/.test(repoFile(`test/e2e/${name}`)));
+  assert.deepEqual(offenders, [],
+    'use startMockServer from test/e2e/mock-server.js — its close() is the fix for the 60s teardown hang');
+});
+
+test('no E2E file closes a server by hand', () => {
+  // `server.close()`, bare and un-awaited, is how five specs used to end: it
+  // neither drops the sockets nor waits for the port, so a listener outlives
+  // the test that made it. `closeAllConnections` is the private copy of the fix
+  // three specs had grown.
+  const offenders = e2eFiles()
+    .filter(name => /server\.close\(|closeAllConnections/.test(repoFile(`test/e2e/${name}`)));
+  assert.deepEqual(offenders, [],
+    'teardown belongs to startMockServer, not to the spec that happened to need it first');
+});


### PR DESCRIPTION
## Background
- This PR packages the current branch changes for review.
- It groups the current branch updates into one reviewable change.

## Solution
- fix(test): stop mock-server teardown from hanging for 60s

## Affected Files
- `test/e2e/clipped-container-translation.spec.js`
- `test/e2e/comic-account.spec.js`
- `test/e2e/comic-translation.spec.js`
- `test/e2e/image-ocr.spec.js`
- `test/e2e/input-translation.spec.js`
- `test/e2e/mock-openai-server.js`
- `test/e2e/mock-server.js`
- `test/e2e/page-translation-highlight-class.spec.js`
- `test/e2e/page-translation-inline-skip.spec.js`
- `test/e2e/page-translation-paper-listing.spec.js`
- `test/e2e/pdf-history-link.spec.js`
- `test/e2e/pdf-translation.spec.js`