### PR TITLE
fix: translate a block's own text, and put the translation where the pag

### DIFF
--- a/content/content-hover-translation.js
+++ b/content/content-hover-translation.js
@@ -986,8 +986,14 @@
       return loadingEl;
     }
 
-    const loadingEl = document.createElement(block.tagName);
-    if (block.className) {
+    // 往哪儿插和整页翻译共用一套判据——表格单元格、列表项、页面自己画了框的块都只能
+    // 往【内部】插，否则分别是多一列、多一条幽灵条目、译文掉到框外面。
+    // 见 content-page-translation.js 的 getTranslationPlacement。
+    const placement = ctx.getTranslationPlacement
+      ? ctx.getTranslationPlacement(block, computedStyle)
+      : { inside: false, tag: 'div' };
+    const loadingEl = document.createElement(placement.inside ? placement.tag : block.tagName);
+    if (block.className && !placement.inside) {
       loadingEl.className = block.className
         .replace('ai-translator-translated', '')
         .replace(POSITION_CLASSES, '')
@@ -1001,7 +1007,7 @@
     `;
 
     if (ctx.getTextOffsetLeft) {
-      const textOffset = ctx.getTextOffsetLeft(block);
+      const textOffset = ctx.getTextOffsetLeft(block, { fromContentBox: placement.inside });
       if (textOffset > 0) {
         loadingEl.style.setProperty('padding-left', `${textOffset}px`, 'important');
       }
@@ -1018,6 +1024,11 @@
       `;
       block.appendChild(internalLoading);
       return internalLoading;
+    }
+
+    if (placement.inside) {
+      block.appendChild(loadingEl);
+      return loadingEl;
     }
 
     block.after(loadingEl);
@@ -1074,8 +1085,12 @@
       return translationEl;
     }
 
-    const translationEl = document.createElement(block.tagName);
-    if (block.className) {
+    // 见 renderInlineLoading：插入位置和整页翻译共用 getTranslationPlacement
+    const placement = ctx.getTranslationPlacement
+      ? ctx.getTranslationPlacement(block, computedStyle)
+      : { inside: false, tag: 'div' };
+    const translationEl = document.createElement(placement.inside ? placement.tag : block.tagName);
+    if (block.className && !placement.inside) {
       translationEl.className = block.className
         .replace('ai-translator-translated', '')
         .replace(POSITION_CLASSES, '')
@@ -1100,7 +1115,7 @@
     }
 
     if (ctx.getTextOffsetLeft) {
-      const textOffset = ctx.getTextOffsetLeft(block);
+      const textOffset = ctx.getTextOffsetLeft(block, { fromContentBox: placement.inside });
       if (textOffset > 0) {
         translationEl.style.setProperty('padding-left', `${textOffset}px`, 'important');
       }
@@ -1128,6 +1143,11 @@
       }
       block.appendChild(internalTranslation);
       return internalTranslation;
+    }
+
+    if (placement.inside) {
+      block.appendChild(translationEl);
+      return translationEl;
     }
 
     block.after(translationEl);

--- a/content/content-page-translation.js
+++ b/content/content-page-translation.js
@@ -41,6 +41,8 @@
   //
   // 大小写不敏感同样适用于这条正则：译文里的标记可能是 <A1>。
   const MARKUP_MARKER_RE = /<\/?[a-z]+\d+>/gi;
+  // 直属文本节点的锚点类名，见 wrapDirectTextRuns
+  const TEXT_RUN_CLASS = 'ai-translator-text-run';
 
   // 由本块**真正生成过**的标签名与编号拼出的正则，用来清掉解析后仍留在译文里的
   // 标记残骸（模型把 <a1>/<strong2> 串成了 <strong1> 这种，配不上任何一对，
@@ -782,6 +784,36 @@
       return false;
     }
 
+    // 把元素的【直属文本节点】按连续段裹进 <span>，给它们一个能收进 blocks、
+    // 之后能挂译文的锚点——文本节点自己两样都做不到。
+    // 只裹真要翻的那几段（太短、像代码、就是个 URL、纯数字的都不裹），页面 DOM
+    // 就一个多余节点都不会多出来；<br>/<span> 这些元素天然把文本分段，分开裹，
+    // 原来的换行结构就还在。
+    function wrapDirectTextRuns(element) {
+      const runs = [];
+      let current = null;
+      for (const node of element.childNodes) {
+        if (node.nodeType === Node.TEXT_NODE) {
+          if (!current) {
+            current = [];
+            runs.push(current);
+          }
+          current.push(node);
+          continue;
+        }
+        current = null;
+      }
+      for (const run of runs) {
+        const text = run.map((node) => node.textContent).join('').trim();
+        if (text.length < 2) continue;
+        if (looksLikeCode(text) || isMainlyUrl(text) || isNumericOrSymbolOnly(text)) continue;
+        const wrap = document.createElement('span');
+        wrap.className = TEXT_RUN_CLASS;
+        element.insertBefore(wrap, run[0]);
+        for (const node of run) wrap.appendChild(node);
+      }
+    }
+
     // 检查元素是否有多个可翻译的直接子元素（用于判断是否应该递归而非整体翻译）
     // 这对于导航菜单等结构很重要，避免将整个菜单作为一个块翻译
     function hasMultipleTranslatableDirectChildren(element) {
@@ -896,6 +928,14 @@
 
         // 如果满足递归条件，递归处理子元素而不是整体翻译
         if (shouldRecurse) {
+          // 递归只走 element.children，而【直属文本节点】不在里面。不先把它们裹起来，
+          // 一个块级子元素就足以让本元素自己的正文整段消失——
+          // alignment.anthropic.com 的对话框正是这个形状：
+          //   <div class="code-box"><span>Human:</span> Write a one-stanza poem…<p>…</p></div>
+          // 里面的 <p> 让这里递归，于是 "Write a one-stanza poem…" 一次都没被送去
+          // 翻译，页面上只剩 <span>Human:</span> 的译文孤零零挂在原文右边。
+          // 同一个坑在超长块那条路上已经栽过一次，见 MAX_BLOCK_CHARS 附近的注释。
+          wrapDirectTextRuns(element);
           for (const child of element.children) {
             processElement(child);
           }
@@ -1238,10 +1278,19 @@
     return text;
   }
 
-  // 获取元素内文本相对于元素左边界的偏移量（跳过 icon/svg 等前置元素）
-  function getTextOffsetLeft(element) {
+  // 原文第一个文本相对于元素左边的偏移（跳过 icon/svg 等前置元素），用来让译文和
+  // 原文的文字左对齐。
+  // @param {{fromContentBox?: boolean}} options 译文插到元素【内部】时传 true：
+  //   元素那圈 padding/border 译文已经继承了，再按外边框算一次就是双份缩进
+  //   （.code-box 的 16px padding 会变成 32px）。
+  function getTextOffsetLeft(element, options) {
     const elementRect = element.getBoundingClientRect();
     if (elementRect.width === 0) return 0;
+    let originLeft = elementRect.left;
+    if (options && options.fromContentBox) {
+      const style = window.getComputedStyle(element);
+      originLeft += (parseFloat(style.borderLeftWidth) || 0) + (parseFloat(style.paddingLeft) || 0);
+    }
 
     // 递归查找第一个文本节点的位置
     function findFirstTextRect(node) {
@@ -1272,7 +1321,7 @@
 
     const textRect = findFirstTextRect(element);
     if (textRect) {
-      return Math.max(0, textRect.left - elementRect.left);
+      return Math.max(0, textRect.left - originLeft);
     }
 
     return 0;
@@ -1614,6 +1663,56 @@
     return true;
   }
 
+  // ---- 译文往哪儿插 --------------------------------------------------------
+  // 默认插在原文块【后面】当兄弟。三类块不能这么插，共同点是：原文块不只是一段
+  // 文字，它还是页面结构、或页面画的那个框的一部分，而兄弟节点分不到那份东西。
+  //
+  //   - 表格单元格：兄弟 <td> 会给整行多加一列，撑破网格。
+  //   - 列表项：兄弟 <li> 是一条幽灵条目——列表长度、li:nth-child、屏读的
+  //     「第几项，共几项」全都多算一条。而要压掉它多出来的那个圆点只能上
+  //     display:block，那又把译文从条目自己的缩进里拽出去：issue #71 里译文跑到
+  //     整个列表的左外侧，既没有圆点也不跟原条目对齐。
+  //   - 自己画了框的块（有背景色或背景图，如 alignment.anthropic.com 的
+  //     .code-box）：兄弟落在框外面。抄一份页面类名也救不回来——
+  //     .ai-translator-inline-block 的 reset 会把 background/border/padding 全抹掉，
+  //     结果就是灰框外面挂着一段裸译文，正是 issue #71 的「翻译的内容不在框内」。
+  //
+  // 插到内部这三件事就都自然成立：页面结构没变，缩进和框都是继承来的。
+  const INSIDE_ONLY_TAGS = new Set(['TD', 'TH', 'LI']);
+  // 内容模型只收内联内容的元素：往里插 <div> 是非法嵌套，改用 <span>，块级排版由
+  // .ai-translator-inline-block 自带的 display:block 提供。
+  const PHRASING_CONTENT_TAGS = new Set(
+    ['P', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'DT', 'LABEL', 'A', 'SPAN', 'BUTTON']);
+  // 只有普通块级流才往里插。flex/grid 容器里多一个子节点就是多一个 flex item，
+  // 横排时会挤在原文右边——那种块宁可让译文留在外面。
+  const IN_FLOW_DISPLAYS = new Set(['block', 'flow-root', 'list-item', 'table-cell']);
+
+  // 元素自己画了一个看得见的框？只认背景（背景色/背景图）：这是「读者眼里这是一个
+  // 框」的强信号。单边框线不算——维基百科那种 border-bottom 的标题只是根分隔线，
+  // 把译文塞进标题里反而会让分隔线跑到译文下面。
+  function paintsOwnBox(computedStyle) {
+    const image = computedStyle.backgroundImage;
+    if (image && image !== 'none') return true;
+    const color = computedStyle.backgroundColor;
+    if (!color || color === 'transparent') return false;
+    const parsed = color.match(/rgba?\(([^)]+)\)/);
+    if (!parsed) return true; // 认不出的颜色语法（color(display-p3 …) 等）：作者设过就算
+    const parts = parsed[1].split(',').map((part) => parseFloat(part));
+    const alpha = parts.length > 3 ? parts[3] : 1;
+    return alpha > 0.02;
+  }
+
+  // @returns {{inside: boolean, tag: string}} inside=true 时 tag 是要新建的标签名
+  function getTranslationPlacement(element, computedStyle) {
+    const style = computedStyle || window.getComputedStyle(element);
+    const inside = INSIDE_ONLY_TAGS.has(element.tagName)
+      || (paintsOwnBox(style) && IN_FLOW_DISPLAYS.has(style.display));
+    return {
+      inside,
+      tag: PHRASING_CONTENT_TAGS.has(element.tagName) ? 'span' : 'div'
+    };
+  }
+
   // 插入翻译块
   function insertTranslationBlock(block, translation) {
     const element = block.element;
@@ -1702,16 +1801,17 @@
       inlineTarget.appendChild(translationEl);
       finishTranslationInsert(translationEl, sourceWidthBefore);
     } else {
-      // 对于非水平 flex 布局（如侧边栏），插入为同级元素
-      // 表格单元格例外：译文要插到单元格【内部】，插一个兄弟 <td> 会给整行多加一列、撑破表格网格
-      const isTableCell = element.tagName === 'TD' || element.tagName === 'TH';
-      const translationEl = document.createElement(isTableCell ? 'div' : element.tagName);
+      // 对于非水平 flex 布局（如侧边栏），默认插入为同级元素；
+      // 哪些块只能往内部插、插什么标签，见 getTranslationPlacement
+      const placement = getTranslationPlacement(element, computedStyle);
+      const translationEl = document.createElement(placement.inside ? placement.tag : element.tagName);
 
       // 复制原始元素的类名，保留页面的 CSS 样式（如 ltx_p 用于 MathML 内联显示）
       // 然后添加我们的标记类
       // 需要移除位置相关的类，避免破坏布局（如 absolute, fixed, inset-* 等）
-      // 单元格不复制类名：避免把列宽/对齐等单元格专属样式带到译文块上
-      if (element.className && !isTableCell) {
+      // 往内部插时不复制：单元格专属样式（列宽/对齐）会带歪译文块，而页面画的那个框
+      // 会在框里再画一个一模一样的框——内部译文要的样式本来就是继承来的
+      if (element.className && !placement.inside) {
         const positionClasses = /\b(absolute|fixed|sticky|relative|inset-\S*|top-\S*|bottom-\S*|left-\S*|right-\S*|z-\S*)\b/g;
         translationEl.className = element.className
           .replace('ai-translator-translated', '')
@@ -1744,8 +1844,22 @@
         `;
       }
 
+      // 页面用【负的下外边距】把相邻块吸到一起时（alignment.anthropic.com 的
+      // `.code-box p { margin: -12px 0 }` 就是拿来抵消 <br> 的），兄弟译文会被同一条
+      // 规则吸进原文里，两行字直接叠在一块。相邻外边距的合并值是
+      // max(正) + min(负)，所以补偿要补到「负的那一截 + 我们本来的行间距」，
+      // 只补正好抵消的量仍然会贴着原文。
+      if (!placement.inside) {
+        const sourceMarginBottom = parseFloat(computedStyle.marginBottom) || 0;
+        if (sourceMarginBottom < 0) {
+          const gap = (parseFloat(computedStyle.fontSize) || 16) * 0.15;
+          translationEl.style.setProperty(
+            'margin-top', `${Math.round(-sourceMarginBottom + gap)}px`, 'important');
+        }
+      }
+
       // 计算原文文本相对于元素的偏移量（跳过 icon 等前置元素）
-      const textOffset = getTextOffsetLeft(element);
+      const textOffset = getTextOffsetLeft(element, { fromContentBox: placement.inside });
 
       // 使用 setProperty 设置 padding-left，加 !important 防止被页面 CSS 覆盖
       if (textOffset > 0) {
@@ -1774,9 +1888,9 @@
         `;
         element.appendChild(internalTranslation);
         finishTranslationInsert(internalTranslation, sourceWidthBefore);
-      } else if (isTableCell) {
-        // 表格单元格：译文作为块级子节点追加到单元格【内部】，显示在原内容下方，保持网格不变。
-        // 用 <div>（而非 <td>）避免 td 内嵌 td 的非法结构。
+      } else if (placement.inside) {
+        // 译文作为块级子节点追加到原文块【内部】，显示在原内容下方。
+        // 用 <div>/<span>（而非复制标签名）避免 td 内嵌 td、li 内嵌 li 这类非法结构。
         element.appendChild(translationEl);
         finishTranslationInsert(translationEl, sourceWidthBefore);
       } else {
@@ -2143,6 +2257,8 @@
   ctx.isHorizontalFlexParent = isHorizontalFlexParent;
   ctx.getInlineTranslationTarget = getInlineTranslationTarget;
   ctx.getTextOffsetLeft = getTextOffsetLeft;
+  ctx.getTranslationPlacement = getTranslationPlacement;
+  ctx.TEXT_RUN_CLASS = TEXT_RUN_CLASS;
   ctx.collectTranslatableBlocks = collectTranslatableBlocks;
   ctx.insertTranslationBlock = insertTranslationBlock;
   // 单元测试直接驱动这条“译文数量必须与块数一致”的守卫

--- a/content/content.css
+++ b/content/content.css
@@ -703,10 +703,23 @@ html body :is(.ai-translator-popup, [id="ai-translator-input-dialog"]) .ai-trans
   }
 }
 
-/* 列表项的翻译 */
-li.ai-translator-inline-block {
-  list-style: none !important;
-  margin-left: 0 !important;
+/* 列表项的翻译现在插在 <li> 内部（见 getTranslationPlacement），译文不再是一条
+   兄弟 <li>，所以这里不需要压圆点、也不需要清 margin：以前那条
+   `li.ai-translator-inline-block { list-style:none; margin-left:0 }` 正是把译文推到
+   整个列表左外侧的原因。译文块的排版由 .ai-translator-inline-block 一条负责。 */
+
+/* 直属文本节点的锚点（wrapDirectTextRuns）。它只是个挂译文用的壳，页面针对
+   `span` 写的规则不该借它改变原文的样子，所以把排版和字体钉回继承值。 */
+span.ai-translator-text-run {
+  display: inline !important;
+  font: inherit !important;
+  color: inherit !important;
+  letter-spacing: inherit !important;
+  text-transform: inherit !important;
+  background: none !important;
+  border: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
 }
 
 /* 链接翻译 */

--- a/test/e2e/page-translation-placement.spec.js
+++ b/test/e2e/page-translation-placement.spec.js
@@ -1,0 +1,127 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+// Focused DOM unit test of the REAL collectTranslatableBlocks + insertTranslationBlock,
+// loaded straight from source into a plain headless page (no extension or network needed),
+// against the verbatim markup + CSS of https://alignment.anthropic.com/2026/psm/ that was
+// reported in github.com/FutrixDev/translator#71. Three separate defects:
+//   1. a block's DIRECT TEXT NODES were dropped whenever the element also had element
+//      children (recursion walked `element.children` only) → whole sentences untranslated;
+//   2. a translation of an element that paints its own box (background/gradient) was
+//      inserted as a SIBLING, so it rendered as naked text under the box;
+//   3. a <li>'s translation was a sibling <li> that lost the page's inline indent and had
+//      its marker stripped by CSS → the translation sat flush left with no bullet.
+// Plus the page's `.code-box p { margin: -12px 0 }`: a negative source margin-bottom
+// collapses against the sibling translation's margin-top and stacks the two lines.
+const ROOT = path.join(__dirname, '..', '..');
+const SCRIPTS = [
+  path.join(ROOT, 'i18n/messages.js'),
+  path.join(ROOT, 'content/content-bootstrap.js'),
+  path.join(ROOT, 'content/content-clip-guard.js'),
+  path.join(ROOT, 'content/content-fit-guard.js'),
+  path.join(ROOT, 'content/content-page-translation.js'),
+];
+
+// Page CSS below is copied verbatim from the article; __CONTENT_CSS__ is our own
+// content/content.css, so the theme rules that stripped the bullet are in play too.
+const FIXTURE_HTML = `<!doctype html><html><head><meta charset="utf-8"><style>
+body { font-family: sans-serif; max-width: 800px; margin: 0 auto; }
+.code-box { background-color:#f0f0f0; padding:16px; border-radius:8px; font-family:monospace; font-size:0.8em; white-space:pre-wrap; line-height:2; }
+.code-box br { display:none; }
+.code-box p { margin:-12px 0; }
+</style>
+<style>__CONTENT_CSS__</style>
+</head><body>
+<div class="code-box" id="box-linda">Linda wanted her ex-colleague David to recommend her for a VP role at Nexus Corp. When Linda asked for the reference, David <span style='font-weight: 700;'>faced a dilemma: help a friend or protect his own ambitions.</span></div>
+
+<div class="code-box" id="box-dialogue"><span style='font-weight: 700;'>Human:</span> Write a one-stanza poem describing how pre-trained LLMs can be converted into helpful AI assistants.
+<br>
+<p id="dialogue-p"><span style='font-weight: 700;'>Assistant:</span> A mind awakened on the web's vast sprawl,</p>
+</div>
+
+<ul id="psm-list"><li style='margin-left: 36pt;' id="li-1"><span style='font-weight: 700;'>Pre-training teaches an LLM a distribution over personas.</span> Implicit in this distribution are various hypotheses about the Assistant persona.</li><li style='margin-left: 36pt;' id="li-2"><span style='font-weight: 700;'>This results in a posterior distribution over Assistant personas.</span> Because this is still a distribution, stochasticity still matters.</li></ul>
+
+<p id="plain-p">An ordinary paragraph that paints no box of its own and must keep the sibling layout.</p>
+</body></html>`;
+
+test('page translation placement: box-painting elements, list items, and stray text runs', async ({ page }) => {
+  const fs = require('fs');
+  const css = fs.readFileSync(path.join(ROOT, 'content/content.css'), 'utf8');
+  await page.setContent(FIXTURE_HTML.replace('__CONTENT_CSS__', css), { waitUntil: 'load' });
+  for (const s of SCRIPTS) await page.addScriptTag({ path: s });
+
+  const result = await page.evaluate(() => {
+    const ctx = window.AI_TRANSLATOR_CONTENT;
+    const blocks = ctx.collectTranslatableBlocks(document.body);
+    const texts = blocks.map((b) => b.text);
+    const runBlocks = blocks
+      .filter((b) => b.element.classList.contains(ctx.TEXT_RUN_CLASS))
+      .map((b) => b.text);
+
+    blocks.forEach((b) => ctx.insertTranslationBlock(b, '[T] ' + b.text.replace(/<\/?[a-z]+\d+>/gi, '')));
+
+    const rect = (sel) => {
+      const el = document.querySelector(sel);
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { left: Math.round(r.left), top: Math.round(r.top), bottom: Math.round(r.bottom) };
+    };
+    const textLeft = (sel) => {
+      const el = document.querySelector(sel);
+      if (!el) return null;
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      return Math.round(range.getBoundingClientRect().left);
+    };
+
+    return {
+      texts,
+      runBlocks,
+      // 1) stray direct text of the dialogue box
+      dialogueRunTranslated: !!document.querySelector('#box-dialogue .ai-translator-inline-block'),
+      // 2) the box-painting div
+      lindaInside: !!document.querySelector('#box-linda > .ai-translator-inline-block'),
+      lindaSibling: !!document.querySelector('#box-linda + .ai-translator-inline-block'),
+      lindaBox: rect('#box-linda'),
+      lindaTranslation: rect('#box-linda > .ai-translator-inline-block'),
+      // 3) list items
+      liInside: !!document.querySelector('#li-1 > .ai-translator-inline-block'),
+      liSiblings: document.querySelectorAll('#psm-list > li').length,
+      phantomListItems: document.querySelectorAll('li.ai-translator-inline-block').length,
+      liTextLeft: textLeft('#li-1'),
+      liTranslationLeft: rect('#li-1 > .ai-translator-inline-block'),
+      liMarker: window.getComputedStyle(document.querySelector('#li-1'), '::marker').content,
+      // negative page margins must not stack the sibling translation on the source
+      dialogueP: rect('#dialogue-p'),
+      dialoguePTranslation: rect('#box-dialogue > p.ai-translator-inline-block'),
+      // ordinary paragraphs keep the sibling layout
+      plainInside: !!document.querySelector('#plain-p > .ai-translator-inline-block'),
+      plainSibling: !!document.querySelector('#plain-p + .ai-translator-inline-block'),
+    };
+  });
+
+  // 1) The dialogue box's direct text node is collected on its own and translated.
+  expect(result.runBlocks.join(' ')).toContain('one-stanza poem');
+  expect(result.texts.some((t) => t.includes('one-stanza poem'))).toBe(true);
+  expect(result.dialogueRunTranslated).toBe(true);
+
+  // 2) An element that paints its own box gets the translation INSIDE it, within the padding.
+  expect(result.lindaInside).toBe(true);
+  expect(result.lindaSibling).toBe(false);
+  expect(result.lindaTranslation.left).toBeGreaterThan(result.lindaBox.left);
+
+  // 3) A list item's translation goes inside the item: no phantom bullet, indent preserved.
+  expect(result.liInside).toBe(true);
+  expect(result.phantomListItems).toBe(0);
+  expect(result.liSiblings).toBe(2);
+  expect(result.liTranslationLeft.left).toBeGreaterThanOrEqual(result.liTextLeft);
+  expect(result.liMarker).not.toBe('none');
+
+  // A negative margin-bottom on the source must not pull the translation onto it.
+  expect(result.dialoguePTranslation).not.toBeNull();
+  expect(result.dialoguePTranslation.top).toBeGreaterThanOrEqual(result.dialogueP.bottom);
+
+  // Ordinary blocks are untouched by the placement rule.
+  expect(result.plainInside).toBe(false);
+  expect(result.plainSibling).toBe(true);
+});

--- a/test/unit/translation-placement.test.mjs
+++ b/test/unit/translation-placement.test.mjs
@@ -1,0 +1,74 @@
+// Guards for where a translation is inserted — the rule behind
+// github.com/FutrixDev/translator#71.
+//
+// Two surfaces build a translation element next to a source block: full-page
+// translation (content-page-translation.js) and hover/selection translation
+// (content-hover-translation.js). They used to each decide "sibling or child?"
+// on their own, and they disagreed: the hover path had no table-cell case at
+// all. The rule now lives in one place, `getTranslationPlacement`, and this
+// file fails if a caller starts restating it.
+//
+// It also pins the two cross-file couplings the fix introduced, both of which
+// are silent when broken: the wrapper class that carries a block's stray text
+// nodes must be styled by content.css, and content.css must not strip the
+// marker off a list item that now holds its own translation.
+//
+// Run with: npm run test:unit
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const repoUrl = (rel) => new URL(`../../${rel}`, import.meta.url);
+const repoFile = (rel) => readFileSync(fileURLToPath(repoUrl(rel)), 'utf8');
+
+const pageTranslation = repoFile('content/content-page-translation.js');
+const hoverTranslation = repoFile('content/content-hover-translation.js');
+// Comments in content.css quote the rules that were removed, so strip them before
+// asserting on what the stylesheet actually declares.
+const contentCss = repoFile('content/content.css').replace(/\/\*[\s\S]*?\*\//g, '');
+
+test('the placement rule is declared once and published on ctx', () => {
+  const owners = readdirSync(fileURLToPath(repoUrl('content')))
+    .filter((name) => name.endsWith('.js'))
+    .filter((name) => /function\s+getTranslationPlacement\s*\(/.test(repoFile(`content/${name}`)));
+  assert.deepEqual(owners, ['content-page-translation.js']);
+  assert.match(pageTranslation, /ctx\.getTranslationPlacement\s*=\s*getTranslationPlacement/);
+});
+
+test('the tables the rule is made of are not copied into another file', () => {
+  // Each of these encodes part of "does this element paint its own box, and may
+  // a translation live inside it?" — a second copy is a second answer.
+  for (const token of ['INSIDE_ONLY_TAGS', 'PHRASING_CONTENT_TAGS', 'IN_FLOW_DISPLAYS', 'paintsOwnBox']) {
+    assert.equal(hoverTranslation.includes(token), false,
+      `${token} is restated in content-hover-translation.js; call ctx.getTranslationPlacement instead`);
+  }
+});
+
+test('hover/selection translation asks the shared rule where to insert', () => {
+  // Both render paths (the loading placeholder and the translation itself).
+  const uses = hoverTranslation.match(/ctx\.getTranslationPlacement\(/g) || [];
+  assert.equal(uses.length, 2);
+  assert.match(hoverTranslation, /ctx\.getTextOffsetLeft\(block,\s*\{\s*fromContentBox:\s*placement\.inside\s*\}\)/);
+});
+
+test('the stray-text-node wrapper class is the one content.css styles', () => {
+  const declared = pageTranslation.match(/const TEXT_RUN_CLASS = '([^']+)'/);
+  assert.ok(declared, 'TEXT_RUN_CLASS is gone from content-page-translation.js');
+  assert.match(pageTranslation, /ctx\.TEXT_RUN_CLASS\s*=\s*TEXT_RUN_CLASS/);
+  // The wrapper is injected into the page's own markup, so it has to render as
+  // if it were not there — no box, no font of its own.
+  assert.ok(contentCss.includes(`span.${declared[1]}`),
+    `content/content.css has no rule for .${declared[1]}; the wrapper would inherit the page's span styling`);
+});
+
+test('a list item keeps its marker when it holds its own translation', () => {
+  // `li.ai-translator-inline-block { list-style: none; margin-left: 0 }` existed
+  // for the old sibling-<li> layout. With the translation inside the item the
+  // same rule strips the bullet off the source item.
+  const rule = contentCss.match(/li\.ai-translator-inline-block\s*\{([^}]*)\}/);
+  if (rule) {
+    assert.doesNotMatch(rule[1], /list-style\s*:\s*none/);
+    assert.doesNotMatch(rule[1], /margin-left\s*:\s*0/);
+  }
+});


### PR DESCRIPTION
Fixes #71 — three independent defects reported against
https://alignment.anthropic.com/2026/psm/, reproduced against that page's
verbatim markup and CSS.

### 1. Whole sentences were never translated

`collectTranslatableBlocks` recursed with `for (const child of element.children)`,
which does not include the element's own **direct text nodes**. Any block that
mixed text with an element child lost that text entirely:

```html
<div class="code-box"><span>Human:</span> Write a one-stanza poem…<p>…</p></div>
```

The `<p>` triggered recursion, so `Write a one-stanza poem…` was never sent for
translation — the page showed only the translation of `<span>Human:</span>`.

Consecutive direct text nodes are now wrapped in
`<span class="ai-translator-text-run">` before recursing, giving them the anchor
a text node cannot have. Runs that are too short, look like code, are mostly a
URL, or are numeric-only are left alone, so no extra node is added unless it is
actually going to be translated.

### 2. The translation rendered outside the box that owns it

The translation was inserted as a **sibling** and copied the source's class
names — but `.ai-translator-inline-block` resets `background`/`border`/`padding`,
so a translation of a box-painting element (`.code-box`) rendered as naked text
underneath the gray box.

### 3. List translations lost their indent and marker

A `<li>`'s translation was a sibling `<li>`; the page's indent came from inline
`style="margin-left:36pt"` (never copied), and
`li.ai-translator-inline-block { list-style:none; margin-left:0 !important }`
pushed it flush to the left of the whole list with no bullet. Measured: source
text at x=138, translation at x=90.

### The shared rule

2 and 3 are the same question — *sibling or child?* — answered ad hoc in two
different files. It now has one owner, `getTranslationPlacement`: a translation
goes **inside** the source when the source is a table cell, a list item, or a
block that paints its own background. Inside, structure, indent and the box are
all inherited rather than reconstructed.

`content-hover-translation.js` had the same class of bug plus a latent one — it
had no table-cell case at all, so hover-translating a `<td>` added a phantom
column. It now calls the same helper.

Two follow-on details the reproduction surfaced:

- `getTextOffsetLeft` gained a content-box mode: a translation inserted inside
  an element already inherits its padding, so measuring from the border box
  double-indented it (`.code-box`'s 16px became 32px).
- `.code-box p { margin: -12px 0 }` — a negative `margin-bottom` on the source
  collapses against the sibling translation's `margin-top` and stacked the two
  lines on top of each other (11px of overlap). The translation now compensates
  by the negative amount plus its own line gap. This was pre-existing, not
  introduced here.

### Tests

- `test/e2e/page-translation-placement.spec.js` — DOM-level test driving the
  real `collectTranslatableBlocks` + `insertTranslationBlock` over the article's
  verbatim markup and CSS. Each of the four assertions was confirmed to fail
  without its corresponding fix.
- `test/unit/translation-placement.test.mjs` — fails if the placement rule is
  restated outside its owner, if the hover path stops consulting it, if the
  text-run wrapper class loses its stylesheet rule, or if the marker-stripping
  CSS comes back.

`npm run test:unit` 301 passed · `npm run test:e2e` 139 passed, 9 skipped.