### PR TITLE
release: 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.2.0 — 2026-08-10
+## 1.3.0 — 2026-08-16
 
 ### New features
 
@@ -14,6 +14,73 @@
   translates through the ordinary path, so Chrome's free built-in Translator
   serves the vision engine too. With the translate step off, the recognised
   text is a complete result and the popup shows it alone.
+- **Region OCR**: a second context-menu entry puts a picker over the image and
+  reads only the rectangle the user drew. What travels is fractions of the
+  image, never pixels — the page and the worker need not hold the same
+  resolution.
+- **Recognise-first**: the menu says "recognise", and translation is an
+  explicit second step from the result popup. `ocrTranslate` now means
+  "auto-translate after recognition" and ships off. An opt-in hover shortcut
+  (`enableImageOcrHoverButton`) offers recognition on images ≥200×200 CSS px
+  through a single delegated listener.
+
+### Fixes
+
+- **A block's own text is translated, and the translation lands where the page
+  has room for it.** Three defects on one reported page. Collection recursed
+  over `element.children`, which excludes an element's *direct text nodes* — so
+  any block that mixed text with an element child lost that text entirely and
+  whole sentences were never sent for translation. Insertion then always chose
+  a sibling: the translation of an element that paints its own background
+  rendered as naked text outside the box (our reset strips
+  `background`/`border`/`padding` off the copied class names), and a list
+  item's translation was a sibling `<li>` that never inherited the page's
+  inline indent and had its marker suppressed, so it sat flush left with no
+  bullet. Direct text runs are now wrapped before recursing, and one rule —
+  `getTranslationPlacement` — decides sibling-or-child for both full-page and
+  hover translation, which had been answering it differently (hover had no
+  table-cell case at all, so hover-translating a `<td>` added a phantom
+  column).
+- **Links survive on the default engine.** Inline-markup preservation was
+  switched off for Chrome's built-in NMT on an assumption that was never
+  measured — and that engine is the default, so most users lost every link in
+  every translation. Measured instead (12 sentences × 3 targets × 3 runs):
+  markers round-trip in the large majority, and the failures are bounded
+  (`<a1>` returns as `<A1>`, a closer occasionally dropped). The reader now
+  tolerates case and whitespace, auto-closes a missing closer, and scrubs
+  debris using a regex built only from the markers that block actually issued,
+  so a page's own prose containing `<b2>` is left alone. 99 links rebuilt on
+  the reported page, 0 debris.
+- **Translations no longer smear over coordinate-driven layouts.** The fit
+  guard judges four geometric conditions — the union of source + translation
+  escaping an enclosing padding box, a source box that cannot hold its own
+  text, and horizontal growth under an absolutely positioned ancestor — and
+  treats dropping the translation as a last resort: it first asks the source
+  to yield, then re-measures. Measured across three pages, introduced overlaps
+  fell to 0/1/1 while translations kept rose.
+- Malformed batch responses route through the alignment guard instead of
+  landing misaligned.
+- Translation-only mode and marker rebuild hardened after review.
+- Host-page CSS: a theme's `.kit button` and its heavier `:hover` twin no
+  longer outrank the controls we style.
+- PDF: one transient failure no longer poisons "translate this PDF" for 24
+  hours.
+- OCR: broken JSON replies raise an error instead of a half-dead popup; lines
+  Tesseract itself did not believe are dropped; the script vote is weighted so
+  OCR-garbage Latin cannot outvote real Han; the auto language pair puts the
+  user's own script before English.
+
+### Permissions added in this release
+
+| permission | why |
+| --- | --- |
+| `offscreen` | Run the bundled Tesseract OCR engine. An MV3 service worker may not spawn a nested Worker or instantiate this WASM, so the offscreen document is the only place it can live. |
+| CSP `wasm-unsafe-eval` on extension pages | Instantiate that same bundled WASM. No remote code is involved: core, worker and language data all ship inside `vendor/tesseract/` and every path is pinned. |
+
+## 1.2.0 — 2026-08-10
+
+### New features
+
 - **PDF translation** (`pdf/`, account-backed): upload a PDF and receive a
   re-typeset translated document produced server-side against the account's
   monthly free page allowance. Ships enabled by default; requires sign-in on

--- a/docs/store-submission-1.3.0.md
+++ b/docs/store-submission-1.3.0.md
@@ -1,0 +1,126 @@
+# Chrome 网上应用店提交说明 — v1.3.0
+
+提交日期：2026-08-18 ｜ 上一个上架版本：1.2.0（2026-08-10）
+
+打包源：`main` @ `ca77f14`（含 PR #72，issue #71 的网页翻译位置修复）。
+
+## 一、包信息
+
+| 项 | 值 |
+| --- | --- |
+| 上传文件 | `ai-translator-1.3.0.zip` |
+| 大小 | 9.1 MB（解压后约 17 MB，其中 16 MB 是本地 OCR 语言包） |
+| 文件数 | 96 |
+| manifest 版本 | 3 |
+| 扩展版本 | 1.3.0 |
+| 最低 Chrome 版本 | 116 |
+
+已核对：manifest 里引用的每个脚本/样式/图标、以及 4 个扩展页面
+（`popup`、`options`、`pdf/upload`、`offscreen`）里引用的每个资源，都在包内；
+无 `.DS_Store`、无 source map、无测试或 `node_modules` 文件；10 种语言的
+`_locales` 齐全。
+
+## 二、本次更新说明（可直接粘贴）
+
+**中文**
+
+> 1.3.0
+> - 新增图片文字识别（OCR）：右键图片即可读出其中的文字，也可以框选图片的某个
+>   区域只识别那一块。默认在本地离线运行，不需要 API Key、不上传图片；也可以
+>   改用你自己的视觉模型。识别与翻译是两步，识别完先给你原文，要不要翻译由你
+>   点一下决定。
+> - 修复：使用 Chrome 内置翻译引擎（默认引擎）时，译文中的超链接会全部丢失。
+> - 修复：在按坐标定位的页面上，译文会盖住原有内容。现在优先让原文让位，实在
+>   放不下才不显示译文。
+> - 修复：整段文字有时不会被翻译——一个段落里只要混有子元素，段落自己的正文
+>   就会被漏掉。
+> - 修复：译文的位置。带底色的方框里，译文会掉到框外面；列表项的译文会跑到列表
+>   左侧、既没有项目符号也不跟原条目对齐。现在这两种译文都插在原文块内部。
+> - 修复：PDF 翻译遇到一次临时失败后，24 小时内无法再次使用。
+> - 修复：部分网站的主题样式会影响插件面板内按钮的外观。
+
+**English**
+
+> 1.3.0
+> - New: image OCR. Right-click an image to read the text in it, or select a
+>   region to read just that part. Runs on-device by default — no API key, no
+>   upload; your own vision model is an alternative. Recognition and
+>   translation are separate steps: you get the recognised text first and
+>   choose whether to translate it.
+> - Fixed: hyperlinks were lost from translations on Chrome's built-in
+>   translation engine (the default engine).
+> - Fixed: on coordinate-driven layouts, translations could overlap existing
+>   content. The source line now yields first; the translation is only dropped
+>   as a last resort.
+> - Fixed: a paragraph's own text could go untranslated whenever the paragraph
+>   also contained a child element.
+> - Fixed: where the translation is placed. Inside a shaded box it rendered
+>   outside the box; a list item's translation sat to the left of the list with
+>   no bullet and no matching indent. Both now render inside the source block.
+> - Fixed: one transient failure disabled PDF translation for 24 hours.
+> - Fixed: some sites' theme CSS could restyle buttons inside our panels.
+
+完整技术记录见 [CHANGELOG.md](../CHANGELOG.md) 的 1.3.0 一节。
+
+## 三、权限理由（Privacy practices 表单逐条填写）
+
+**本次相对 1.2.0 新增的只有 `offscreen` 一项，以及扩展页面 CSP 里的
+`wasm-unsafe-eval`** —— 这两项都只为本地 OCR 引擎服务，是审核最可能追问的点。
+
+| 权限 | 理由（可直接粘贴） |
+| --- | --- |
+| `offscreen` 🆕 | Runs the bundled Tesseract OCR engine, which needs a Web Worker and WebAssembly. An MV3 service worker cannot spawn a nested Worker or instantiate this WASM, so an offscreen document is the only place this engine can run. It is created on demand for a recognition request and closed afterwards. |
+| CSP `wasm-unsafe-eval` 🆕 | Required to instantiate the bundled Tesseract WebAssembly module on our own extension pages. No remote code is involved — the core, the worker and the language data all ship inside the package under `vendor/tesseract/`, and every path is pinned so the library's CDN defaults are never used. |
+| `storage` | Stores the user's own settings (API endpoint, model, target language, feature toggles) and the sign-in token. |
+| `activeTab` | Runs a translation on the tab the user explicitly acted on (toolbar button or context menu). |
+| `contextMenus` | The right-click entries for translating a selection/page and for recognising text in an image. |
+| `identity` | `chrome.identity.getRedirectURL()` / web auth flow for signing in to the optional account used by comic and PDF translation. |
+| `notifications` | Server-side PDF translation outlives the page that started it; the notification tells the user when the job finished or failed. |
+| `alarms` | Polls that PDF job's status once a minute — an MV3 service worker cannot hold a long-lived timer. |
+| `<all_urls>` | The extension's single purpose is translating the page the user is on, and that can be any page. Content scripts only translate when the user asks; no page content is read or sent otherwise. |
+
+**Single purpose**（如需重填）：Translate web content — selected text, whole
+pages, video subtitles, text inside images, and PDFs — using a translation
+engine the user chooses.
+
+**Remote code**：选 **"No, I am not using remote code"**。所有 JS/WASM 都在包
+内；扩展只通过网络传输数据（翻译请求/响应），不下载或执行远程代码。
+
+**数据用途**：用户文本被发送到用户自己配置的 OpenAI 兼容接口以完成翻译；漫画和
+PDF 翻译发送到我方服务器处理。不出售数据、不用于与功能无关的用途、不做信用评估。
+
+## 四、给审核员的测试说明（Reviewer notes，建议填写）
+
+不需要账号即可验证的功能（本次更新的主体）：
+
+1. 图片 OCR（本地引擎，无需任何配置）：在任意网页右键一张含文字的图片 →
+   "识别图片中的文字"。首次会加载本地语言包，随后弹窗显示识别出的文字，
+   点击弹窗中的"翻译"按钮才会进行翻译。
+2. 区域 OCR：右键图片 → "识别选定区域的文字"，在图片上拖出一个矩形。
+3. 网页翻译：点击工具栏图标 → 翻译此页面（默认使用 Chrome 内置翻译引擎，
+   无需 API Key）。
+
+需要账号的功能（**非本次更新内容**，1.1.1/1.2.0 已上架）：漫画翻译、PDF 翻译
+运行在我方服务器上，需登录后使用每月免费额度。若审核需要，请提供测试账号。
+
+## 五、提交前 checklist
+
+- [x] `manifest.json` 版本已升到 1.3.0（高于已上架的 1.2.0）
+- [x] `npm run test:unit` 全绿（301 passed）
+- [x] `npm run zip` 产物完整性已校验（引用无缺失、无多余文件）
+- [x] CHANGELOG 1.3.0 一节已写（并把此前误记在 1.2.0 下的 OCR 条目移到了这里
+      —— 8/10 上架的 1.2.0 包里并不含 OCR）
+- [x] `npm run test:e2e` 整轮 139 passed / 9 skipped / 0 failed。
+      （那条 `comic-account.spec.js` 的 60s 超时是 mock server 拆卸时挂住，已由
+      `e00bcb7 fix(test): stop mock-server teardown from hanging for 60s` 修掉。）
+- [ ] 在 `chrome://extensions/` 用"加载已解压的扩展程序"实测一遍 1.3.0 的
+      OCR 与网页翻译
+- [ ] 上传 zip、粘贴上面的更新说明与权限理由、提交审核
+
+## 六、一个需要你确认的点
+
+商店的简介文案是"免费、安全、无中间服务器的 AI 翻译"（英文 `no middleman`），
+而漫画翻译和 PDF 翻译确实会把文件上传到我方服务器处理。这两句话放在一起，审核
+方在核对数据用途声明时可能会认为描述与实际不符。建议把简介改成类似"网页翻译不
+经过中间服务器"的限定说法，或在详细说明里写清楚哪些功能会上传文件。这次可以先
+提交，但迟早要对齐。

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "__MSG_appDescription__",
   "default_locale": "en",
   "minimum_chrome_version": "116",


### PR DESCRIPTION
Release prep for the 1.3.0 Chrome Web Store submission. No behaviour change — version bump, changelog and submission notes only.

- `manifest.json` 1.2.0 → 1.3.0
- `CHANGELOG.md`: the 1.3.0 section, including the OCR entries that were previously filed under 1.2.0 (the 1.2.0 package shipped on 2026-08-10 did not contain OCR), plus an entry for the #71 placement fix merged in #72.
- `docs/store-submission-1.3.0.md`: paste-ready release notes in both languages, per-permission justifications for the Privacy practices form, reviewer notes, and the pre-submission checklist. Records the packaged commit (`main` @ ca77f14).

The uploaded package `ai-translator-1.3.0.zip` is built from `main` at ca77f14 — 9.1 MB, 96 files, contents verified (every referenced script/style/icon present, no source maps, no test files, all 10 `_locales`).

`npm run test:unit` 301 passed · `npm run test:e2e` 139 passed, 9 skipped.