### PR TITLE
release: 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.3.1 — 2026-08-18
+
+### Fixes
+
+- **A block's own text is translated, and the translation lands where the page
+  has room for it.** Three defects on one reported page. Collection recursed
+  over `element.children`, which excludes an element's *direct text nodes* — so
+  any block that mixed text with an element child lost that text entirely and
+  whole sentences were never sent for translation. Insertion then always chose
+  a sibling: the translation of an element that paints its own background
+  rendered as naked text outside the box (our reset strips
+  `background`/`border`/`padding` off the copied class names), and a list
+  item's translation was a sibling `<li>` that never inherited the page's
+  inline indent and had its marker suppressed, so it sat flush left with no
+  bullet. Direct text runs are now wrapped before recursing, and one rule —
+  `getTranslationPlacement` — decides sibling-or-child for both full-page and
+  hover translation, which had been answering it differently (hover had no
+  table-cell case at all, so hover-translating a `<td>` added a phantom
+  column).
+
 ## 1.3.0 — 2026-08-16
 
 ### New features
@@ -26,21 +46,6 @@
 
 ### Fixes
 
-- **A block's own text is translated, and the translation lands where the page
-  has room for it.** Three defects on one reported page. Collection recursed
-  over `element.children`, which excludes an element's *direct text nodes* — so
-  any block that mixed text with an element child lost that text entirely and
-  whole sentences were never sent for translation. Insertion then always chose
-  a sibling: the translation of an element that paints its own background
-  rendered as naked text outside the box (our reset strips
-  `background`/`border`/`padding` off the copied class names), and a list
-  item's translation was a sibling `<li>` that never inherited the page's
-  inline indent and had its marker suppressed, so it sat flush left with no
-  bullet. Direct text runs are now wrapped before recursing, and one rule —
-  `getTranslationPlacement` — decides sibling-or-child for both full-page and
-  hover translation, which had been answering it differently (hover had no
-  table-cell case at all, so hover-translating a `<td>` added a phantom
-  column).
 - **Links survive on the default engine.** Inline-markup preservation was
   switched off for Chrome's built-in NMT on an assumption that was never
   measured — and that engine is the default, so most users lost every link in

--- a/docs/store-submission-1.3.0.md
+++ b/docs/store-submission-1.3.0.md
@@ -1,8 +1,9 @@
 # Chrome 网上应用店提交说明 — v1.3.0
 
-提交日期：2026-08-18 ｜ 上一个上架版本：1.2.0（2026-08-10）
+提交日期：2026-08-16 ｜ 上一个上架版本：1.2.0（2026-08-10）
 
-打包源：`main` @ `ca77f14`（含 PR #72，issue #71 的网页翻译位置修复）。
+本文档记录的是 **1.3.0** 那次提交。issue #71 的网页翻译位置修复没有赶上这个包，
+随 1.3.1 发布，见 [store-submission-1.3.1.md](store-submission-1.3.1.md)。
 
 ## 一、包信息
 
@@ -32,10 +33,6 @@
 > - 修复：使用 Chrome 内置翻译引擎（默认引擎）时，译文中的超链接会全部丢失。
 > - 修复：在按坐标定位的页面上，译文会盖住原有内容。现在优先让原文让位，实在
 >   放不下才不显示译文。
-> - 修复：整段文字有时不会被翻译——一个段落里只要混有子元素，段落自己的正文
->   就会被漏掉。
-> - 修复：译文的位置。带底色的方框里，译文会掉到框外面；列表项的译文会跑到列表
->   左侧、既没有项目符号也不跟原条目对齐。现在这两种译文都插在原文块内部。
 > - 修复：PDF 翻译遇到一次临时失败后，24 小时内无法再次使用。
 > - 修复：部分网站的主题样式会影响插件面板内按钮的外观。
 
@@ -52,11 +49,6 @@
 > - Fixed: on coordinate-driven layouts, translations could overlap existing
 >   content. The source line now yields first; the translation is only dropped
 >   as a last resort.
-> - Fixed: a paragraph's own text could go untranslated whenever the paragraph
->   also contained a child element.
-> - Fixed: where the translation is placed. Inside a shaded box it rendered
->   outside the box; a list item's translation sat to the left of the list with
->   no bullet and no matching indent. Both now render inside the source block.
 > - Fixed: one transient failure disabled PDF translation for 24 hours.
 > - Fixed: some sites' theme CSS could restyle buttons inside our panels.
 
@@ -106,13 +98,13 @@ PDF 翻译发送到我方服务器处理。不出售数据、不用于与功能�
 ## 五、提交前 checklist
 
 - [x] `manifest.json` 版本已升到 1.3.0（高于已上架的 1.2.0）
-- [x] `npm run test:unit` 全绿（301 passed）
+- [x] `npm run test:unit` 全绿（284 passed）
 - [x] `npm run zip` 产物完整性已校验（引用无缺失、无多余文件）
 - [x] CHANGELOG 1.3.0 一节已写（并把此前误记在 1.2.0 下的 OCR 条目移到了这里
       —— 8/10 上架的 1.2.0 包里并不含 OCR）
-- [x] `npm run test:e2e` 整轮 139 passed / 9 skipped / 0 failed。
-      （那条 `comic-account.spec.js` 的 60s 超时是 mock server 拆卸时挂住，已由
-      `e00bcb7 fix(test): stop mock-server teardown from hanging for 60s` 修掉。）
+- [x] `npm run test:e2e` 整轮复跑 138 passed / 9 skipped / 0 failed。
+      （第一轮曾有 1 条 `comic-account.spec.js` 的 60s 超时。当时判为偶发；后来
+      查明是 mock server 拆卸时挂住，已由 `e00bcb7` 修掉。）
 - [ ] 在 `chrome://extensions/` 用"加载已解压的扩展程序"实测一遍 1.3.0 的
       OCR 与网页翻译
 - [ ] 上传 zip、粘贴上面的更新说明与权限理由、提交审核

--- a/docs/store-submission-1.3.1.md
+++ b/docs/store-submission-1.3.1.md
@@ -1,0 +1,76 @@
+# Chrome 网上应用店提交说明 — v1.3.1
+
+提交日期：2026-08-18 ｜ 上一个上架版本：1.3.0（2026-08-16 提交）
+
+补丁版本，只修 bug：没有新功能、没有新权限、没有新的数据用途。权限理由表单与
+1.3.0 完全一致，见 [store-submission-1.3.0.md](store-submission-1.3.0.md) 第三节，
+逐条照填即可。
+
+## 一、包信息
+
+| 项 | 值 |
+| --- | --- |
+| 上传文件 | `ai-translator-1.3.1.zip` |
+| 大小 | 9.1 MB（解压后约 17 MB，其中 16 MB 是本地 OCR 语言包） |
+| 文件数 | 96 |
+| manifest 版本 | 3 |
+| 扩展版本 | 1.3.1 |
+| 最低 Chrome 版本 | 116 |
+| 打包源 | `main` @ PR #72 合并之后 |
+
+与 1.3.0 的包相比，文件清单完全相同，只有三个内容脚本和版本号变了：
+`content/content-page-translation.js`、`content/content-hover-translation.js`、
+`content/content.css`。
+
+## 二、本次更新说明（可直接粘贴）
+
+**中文**
+
+> 1.3.1
+> - 修复：整段文字有时不会被翻译。一个段落里只要混有子元素（比如加粗、链接后面
+>   还跟着一个小段落），段落自己的正文就会被整段漏掉。
+> - 修复：译文出现的位置。带底色的方框（例如文档站的对话框、代码框）里，译文会
+>   掉到框的外面变成一段裸文字；列表项的译文会跑到整个列表的左侧，既没有项目
+>   符号，也不跟原条目对齐。现在这两种情况下译文都插在原文块内部，保持页面原有
+>   的边框、底色和缩进。
+> - 修复：页面用负边距把相邻两行吸到一起时，译文会和原文叠在一起。
+
+**English**
+
+> 1.3.1
+> - Fixed: a paragraph's own text could go untranslated. Whenever a paragraph
+>   also contained a child element, the paragraph's own sentences were skipped
+>   entirely.
+> - Fixed: where translations are placed. Inside a shaded box (a documentation
+>   site's dialogue or code box) the translation rendered outside the box as
+>   bare text; a list item's translation sat to the left of the whole list with
+>   no bullet and no matching indent. Both now render inside the source block,
+>   keeping the page's own border, background and indentation.
+> - Fixed: on pages that pull adjacent lines together with negative margins,
+>   the translation could overlap the original text.
+
+完整技术记录见 [CHANGELOG.md](../CHANGELOG.md) 的 1.3.1 一节。
+
+## 三、给审核员的测试说明（Reviewer notes）
+
+本次改动只影响网页翻译时译文插入 DOM 的位置，不涉及网络请求、权限或数据处理。
+可复现页面：`https://alignment.anthropic.com/2026/psm/`，对整页执行翻译，观察
+带底色的对话框与项目符号列表——1.3.0 上译文会掉到框外、列表译文没有项目符号，
+1.3.1 上两者都在原文块内部。
+
+## 四、提交前 checklist
+
+- [x] `manifest.json` 版本已升到 1.3.1（高于已提交的 1.3.0）
+- [x] `npm run test:unit` 全绿（301 passed）
+- [x] `npm run test:e2e` 139 passed / 9 skipped / 0 failed
+- [x] `npm run zip` 产物已校验：96 个文件、10 种 `_locales` 齐全、Tesseract 核心
+      与 5 个语言包在内、无 `.DS_Store`、无 source map、无测试文件
+- [ ] 在 `chrome://extensions/` 用"加载已解压的扩展程序"实测一遍网页翻译
+- [ ] 上传 zip、粘贴上面的更新说明；权限理由沿用 1.3.0 的答案
+
+## 五、仍未解决的一点
+
+商店简介文案是"免费、安全、无中间服务器的 AI 翻译"（英文 `no middleman`），而
+漫画翻译和 PDF 翻译确实会把文件上传到我方服务器处理。1.3.0 提交时就记过这一条，
+仍然没改。建议改成"网页翻译不经过中间服务器"这种限定说法，或在详细说明里写清楚
+哪些功能会上传文件。

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "__MSG_appDescription__",
   "default_locale": "en",
   "minimum_chrome_version": "116",


### PR DESCRIPTION
1.3.0 is already uploaded to the Chrome Web Store, so the translation-placement fix from #72 ships as 1.3.1. No code change here — version bump, changelog and submission notes only.

- `manifest.json` 1.3.0 → 1.3.1
- `CHANGELOG.md`: new 1.3.1 section. The #71 entry moved out of 1.3.0, which did not contain the fix.
- `docs/store-submission-1.3.1.md`: package info, paste-ready release notes in both languages, reviewer notes with the reproduction page, and the checklist. It points at the 1.3.0 doc for the permission answers — this is a patch release with no new permissions and no new data use.
- `docs/store-submission-1.3.0.md` restored to what it recorded at the time of that submission: the four release-note bullets describing the #71 fix are removed (that build did not have it), the test counts go back to the tree that was actually packaged, and the header now points forward to 1.3.1. The one substantive correction kept is the `comic-account.spec.js` 60s timeout — recorded then as an intermittent flake, since traced to the mock-server teardown hang fixed by `e00bcb7`.

Package: `ai-translator-1.3.1.zip`, 9.1 MB, 96 files — the same file list as the 1.3.0 package, with three content scripts and the version changed.

`npm run test:unit` 301 passed · `npm run test:e2e` 139 passed, 9 skipped.